### PR TITLE
Arrays in config files

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
@@ -122,6 +122,8 @@ class TemplateConfigDsl implements Serializable{
       }else{
         if (value instanceof String){
           file += "${tab*depth}${key} = '${StringEscapeUtils.escapeJava(value)}'"
+        } else if (value instanceof ArrayList){
+          file += "${tab*depth}${key} = ${value.inspect()}" 
         }else{
           file += "${tab*depth}${key} = ${value}" 
         }

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
@@ -257,4 +257,19 @@ class TemplateConfigDslSpec extends Specification {
             thrown(TemplateConfigException)
     }
 
+    def "array lists are appropriately serialized"(){
+        setup: 
+            String config = "field = [ 'a', 'b-c' ]"
+            Map expectedConfig = [
+                field: [ "a", "b-c" ]
+            ]
+            def originalConfig, reparsedConfig
+        when: 
+            originalConfig = TemplateConfigDsl.parse(config)
+            reparsedConfig = TemplateConfigDsl.parse(TemplateConfigDsl.serialize(originalConfig))
+        then: 
+            originalConfig.getConfig() == expectedConfig
+            reparsedConfig.getConfig() == expectedConfig
+    }
+
 }


### PR DESCRIPTION
# PR Details

having a configuration file with a field such as
~~~
field = [ "a", "b-c" ]
~~~

resulted in the exception: 

~~~
java.lang.SecurityException: 
        onMethodCall:
        invoker -> org.kohsuke.groovy.sandbox.impl.Checker$1@ab631b1
        receiver -> PROPERTY_MISSING
        method -> minus
        args -> [PROPERTY_MISSING]
~~~

being thrown. 

Ended up being because ``TemplateConfigDsl.serialize`` did not appropriately handle arrays. 

## Description

updated TemplateConfigDsl.serialize to properly handle arrays via the ``inspect()`` method.

## How Has This Been Tested

wrote a unit test for this case.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
