### PR TITLE
Pipeline Job Flow Definition to pass template and config file directly

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,12 +72,22 @@ create a more organized code base for your pipelines.
 .. toctree::
    :hidden:
    :titlesonly:
-   :caption: Pipeline Templating 💡
+   :caption: Pipeline Templating 🧩
 
    pages/Pipeline_Templating/what_is_a_pipeline_template
    pages/Pipeline_Templating/configuration_files
    pages/Pipeline_Templating/configuration_file_sandboxing
    
+.. toctree::
+   :hidden: 
+   :titlesonly:
+   :caption: Job Types ⚙️
+
+   pages/Job_Configurations/template_step
+   pages/Job_Configurations/pipeline
+   pages/Job_Configurations/repository
+   pages/Job_Configurations/github_org
+
 .. toctree::
    :hidden:
    :titlesonly:

--- a/docs/pages/Job_Configurations/github_org.rst
+++ b/docs/pages/Job_Configurations/github_org.rst
@@ -1,0 +1,5 @@
+.. _GitHub Organization Job:
+
+-----------------------
+GitHub Organization Job
+-----------------------

--- a/docs/pages/Job_Configurations/pipeline.rst
+++ b/docs/pages/Job_Configurations/pipeline.rst
@@ -1,0 +1,5 @@
+.. _Pipeline Jobs: 
+
+------------------------
+Individual Pipeline Jobs
+------------------------

--- a/docs/pages/Job_Configurations/repository.rst
+++ b/docs/pages/Job_Configurations/repository.rst
@@ -1,0 +1,5 @@
+.. _Multibranch Job: 
+
+---------------
+Multibranch Job
+---------------

--- a/docs/pages/Job_Configurations/template_step.rst
+++ b/docs/pages/Job_Configurations/template_step.rst
@@ -1,0 +1,76 @@
+.. _Template Step: 
+
+-----------------
+The Template Step
+-----------------
+
+The Jenkins Templating Engine adds a pipeline step called ``template`` that can be called from a pipeline. 
+
+This step is typically called indirectly when using a :ref:`Multibranch Job <Multibranch Job>` or when
+creating a :ref:`GitHub Organization Job <GitHub Organization Job>`. 
+
+When this step is executed, the pipeline will have access to the primitives that have been defined via 
+the aggregated result of the specified pipeline configuration files as well as any steps that have been 
+contributed by loaded libraries. 
+
+===================================================
+Set the Template implicitely from a Governance Tier 
+===================================================
+
+The real power in the Jenkins Templating Engine is that it allows you to 
+externalize the Jenkinsfile from an individual source code repository, and 
+generalize it to be used by multiple teams simultaneously. 
+
+This means that the default way to define a Template is externally in a source 
+code repository via a Governance Tier. 
+
+This is exactly what happens when you invoke the ``template`` step directly 
+with no parameters via ``template()``. 
+
+When no parameters are passed, the pipeline configuration files defined on 
+each Governance Tier are aggregated.  This aggregated configuration is then used 
+to initialize the Template's environment with the various Primitives that were defined
+as well as load any libraries that have been configured. 
+
+==============================
+Set the Template via a Closure 
+==============================
+
+The ``template`` step itself takes an optional ``Closure`` parameter.  This ``Closure`` parameter 
+is most often used for testing, though if governance is not a factor it works just as well as 
+defining your pipeline template externally. 
+
+An Example
+^^^^^^^^^^
+
+Let's assume that you are running a typical Jenkinsfile and want to invoke the ``template`` step directly.
+
+You have configured a Governance Tier that will load a library contributing a ``build()`` step. 
+
+Executing this ``build`` step then, can be done by trying to invoke it from within the context of the 
+``template`` step as follows: 
+
+.. code:: groovy
+
+    /*
+        here you do not have access to the 
+        build step because it has not been loaded yet
+    */
+    template{
+        /*
+            now that you are within the context of the 
+            template step, the library will have been loaded
+            and you will be able to execute the build step
+        */
+        build() 
+    }
+
+.. note:: 
+
+    When a ``Closure`` is passed to the ``template`` step - we do not look for a 
+    template, regardless if a Governance Tier specifies what template should be used. 
+
+    This is because if you want to restrict what template should be used, it's best 
+    to use a Multibranch or GitHub Organization job to apply these standards across 
+    entire repositories or organizations.  
+

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
@@ -32,7 +32,7 @@ public class TemplateBranchProjectFactory extends WorkflowBranchProjectFactory {
     @DataBoundConstructor public TemplateBranchProjectFactory() {}
 
     @Override protected FlowDefinition createDefinition() {
-        return new TemplateFlowDefinition()
+        return new MultibranchTemplateFlowDefinition()
     }
 
     @Override

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/config.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/config.jelly
@@ -1,0 +1,36 @@
+<?jelly escape-by-default='true'?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2013-2014, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:wfe="/org/jenkinsci/plugins/workflow/editor">
+  <f:entry title="${%Pipeline Template}" field="template">
+    <wfe:workflow-editor />
+  </f:entry>
+  <f:entry field="sandbox">
+    <f:checkbox title="${%Use Groovy Sandbox}" default="true"/>
+  </f:entry>
+  <f:entry title="${%Pipeline Configuration}" field="pipelineConfig">
+    <wfe:workflow-editor />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/config.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/config.jelly
@@ -25,12 +25,16 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:wfe="/org/jenkinsci/plugins/workflow/editor">
   <f:entry title="${%Pipeline Template}" field="template">
-    <wfe:workflow-editor />
+    <wfe:workflow-editor>
+      <div class="samples"/>
+    </wfe:workflow-editor>
   </f:entry>
   <f:entry field="sandbox">
     <f:checkbox title="${%Use Groovy Sandbox}" default="true"/>
   </f:entry>
   <f:entry title="${%Pipeline Configuration}" field="pipelineConfig">
-    <wfe:workflow-editor />
+    <wfe:workflow-editor>
+      <div class="samples"/>
+    </wfe:workflow-editor>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-pipelineConfig.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-pipelineConfig.html
@@ -1,0 +1,3 @@
+<p>
+    A Pipeline Configuration file that will be used when loading this Pipeline.
+</p>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-sandbox.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-sandbox.html
@@ -1,0 +1,4 @@
+<div>
+    If checked, run this Pipeline Template in a sandbox with limited abilities.
+    If unchecked, and you are not a Jenkins administrator, you will need to wait for an administrator to approve the template.
+</div>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-template.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateFlowDefinition/help-template.html
@@ -1,0 +1,3 @@
+<p>
+    Pipeline Template used for this Pipeline.
+</p>

--- a/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
@@ -14,6 +14,7 @@
 package org.boozallen.plugins.jte.config
 
 import org.boozallen.plugins.jte.console.TemplateLogger
+import org.boozallen.plugins.jte.job.TemplateFlowDefinition
 import org.boozallen.plugins.jte.utils.RunUtils
 import spock.lang.*
 import org.junit.Rule
@@ -298,6 +299,31 @@ class GovernanceTierSpec extends Specification{
         then: 
             assert list instanceof List<GovernanceTier> 
             assert list == expectedResult 
+    }
+
+     def "Get Governance Hierarchy: Global config and job level config"(){
+        given: 
+            TemplateGlobalConfig global = TemplateGlobalConfig.get() 
+            global.setTier(tier1) 
+
+            String pipelineConfig = "field = 1" 
+            WorkflowJob currentJob = jenkins.createProject(WorkflowJob, jenkins.createUniqueProjectName())
+            TemplateFlowDefinition flowDef = new TemplateFlowDefinition("template", true, pipelineConfig)
+            currentJob.setDefinition(flowDef)
+
+            GroovySpy(RunUtils, global:true)
+            _ * RunUtils.getJob() >> currentJob
+
+            GroovyMock(TemplateLogger, global:true)
+            _ * TemplateLogger.print(_,_)
+
+            def list 
+        when: 
+            list = GovernanceTier.getHierarchy()
+        then: 
+            assert list instanceof List<GovernanceTier> 
+            assert list.size() == 2 
+            assert list.get(0).getPipelineConfig() == pipelineConfig 
     }
 
     WorkflowJob getWorkflowJob(){


### PR DESCRIPTION
# PR Details

When using a regular Pipeline Job, the ``template`` step allows you to pass a closure that will be executed after initializing the binding based upon what's in the aggregated pipeline configuration. 

These Pipeline jobs do not necessarily require that an SCM be used, meaning that there was no way to add a job level ``pipeline_config.groovy`` file. 

This change adds a new FlowDefinition to Pipeline Jobs that allows you to specify your pipeline template and pipeline configuration file directly in the Jenkins UI. 

## Description

1. Renamed the existing Flow Definition to ``MultibranchFlowDefinition`` as it is only used in the context of Multibranch and GitHub Organization jobs. 
2. Created a new ``TemplateFlowDefinition`` for the purposes described above
3. Updated ``GovernanceTier.getHierarchy()`` to check if the job contains a ``TemplateFlowDefinition``  and adds a Governance Tier if it does. 
4. ``GovernanceTier`` did not support getting a ``TemplateConfigObject`` from anything but SCM, so added a ``pipelineConfig`` field.  When this field is populated via ``setPipelineConfig``, we parse the configuration file stored in this field directly.  When the field is null, we load the file from SCM as was the old behavior


## How Has This Been Tested

Manual testing and unit tests

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
