### PR TITLE
ApplicationEnvironments can determine previous/next environment

### DIFF
--- a/docs/pages/Primitives/application_environments.rst
+++ b/docs/pages/Primitives/application_environments.rst
@@ -42,6 +42,47 @@ accepts an application environment as an argument, you could reference these obj
     test()
     deploy_to prod 
 
+*******************
+Determining Context
+*******************
+
+A created ApplicationEnvironment can determine the previous and next ApplicationEnvironment that's 
+been defined through the ``previous`` and ``next`` properties.  
+
+The first environment's ``previous`` property and the last environment's ``next`` property will be ``null``. 
+
+For example, defining: 
+
+.. code:: 
+
+    application_environments{
+        dev{
+            long_name = "Development"
+        }
+        test{
+            long_name = "Test" 
+        }
+        prod{
+            long_name = "Production" 
+        }
+    }
+
+This will create ``dev``, ``test``, and ``prod`` objects to be leveraged in your libraries and templates. 
+
+.. code:: 
+    // validate dev environment's context 
+    assert dev.previous == null
+    assert dev.next == test 
+
+    // validate test environment's context
+    assert test.previous == dev 
+    assert test.next == prod 
+
+    // validate prod environment's context 
+    assert prod.previous == test 
+    assert prod.next == null 
+    
+
 *************************
 Additional Configurations 
 *************************

--- a/docs/pages/Primitives/application_environments.rst
+++ b/docs/pages/Primitives/application_environments.rst
@@ -51,6 +51,11 @@ been defined through the ``previous`` and ``next`` properties.
 
 The first environment's ``previous`` property and the last environment's ``next`` property will be ``null``. 
 
+.. note:: 
+
+    These properties are automatically configured.  If you try to set the ``previous`` and ``next`` properties
+    in the environment's definition an exception will be thrown. 
+
 For example, defining: 
 
 .. code:: 
@@ -68,6 +73,8 @@ For example, defining:
     }
 
 This will create ``dev``, ``test``, and ``prod`` objects to be leveraged in your libraries and templates. 
+
+Then, to validate their context you could create a template such as: 
 
 .. code:: 
 

--- a/docs/pages/Primitives/application_environments.rst
+++ b/docs/pages/Primitives/application_environments.rst
@@ -70,6 +70,7 @@ For example, defining:
 This will create ``dev``, ``test``, and ``prod`` objects to be leveraged in your libraries and templates. 
 
 .. code:: 
+
     // validate dev environment's context 
     assert dev.previous == null
     assert dev.next == test 

--- a/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentInjector.groovy
@@ -22,13 +22,24 @@ import org.boozallen.plugins.jte.binding.*
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 import hudson.Extension 
 import jenkins.model.Jenkins
+import com.cloudbees.groovy.cps.NonCPS
 
 @Extension class ApplicationEnvironmentInjector extends TemplatePrimitiveInjector {
 
+    @NonCPS
     static void doInject(TemplateConfigObject config, CpsScript script){
         Class ApplicationEnvironment = getPrimitiveClass()
+        ArrayList createdEnvs = [] 
         config.getConfig().application_environments.each{ name, appEnvConfig ->
-            script.getBinding().setVariable(name, ApplicationEnvironment.newInstance(name, appEnvConfig))
+            def env = ApplicationEnvironment.newInstance(name, appEnvConfig)
+            createdEnvs << env 
+            script.getBinding().setVariable(name, env)
+        }
+        createdEnvs.eachWithIndex{ env, index -> 
+            def previous = index ? createdEnvs[index - 1] : null  
+            def next = (index != (createdEnvs.size() - 1)) ? createdEnvs[index + 1] : null 
+            env.setPrevious(previous)
+            env.setNext(next)
         }
     }
 

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
@@ -40,6 +40,18 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
 
         short_name = _config.short_name ?: var_name 
         long_name = _config.long_name ?: var_name 
+
+        /*
+            users cant define the previous or next properties. they'll
+            just be ignored. so throw an exception if they try. 
+        */
+
+        def context = _config.subMap(["previous", "next"])
+        if(context){
+            throw new TemplateConfigException("""Error configuring ApplicationEnvironment ${var_name}
+            The previous and next configuration options are reserved and auto-populated. 
+            """)
+        }
         
         config = _config - _config.subMap(["short_name", "long_name"])
         /*

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
@@ -29,6 +29,9 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
     String short_name
     String long_name
     final def config
+    ApplicationEnvironment previous 
+    ApplicationEnvironment next 
+
     
     ApplicationEnvironment(){}
 

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironment.groovy
@@ -50,7 +50,7 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
         if(context){
             throw new TemplateConfigException("""Error configuring ApplicationEnvironment ${var_name}
             The previous and next configuration options are reserved and auto-populated. 
-            """)
+            """.stripIndent())
         }
         
         config = _config - _config.subMap(["short_name", "long_name"])

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
@@ -187,6 +187,18 @@ class ApplicationEnvironmentSpec extends Specification{
             assert ex.message == "Variable dev is reserved as an Application Environment." 
     }
 
+    def "first environment's previous is null"{
+        when: 
+            injectEnvironments([
+                dev: [ long_name: "Development" ]
+            ])
+            binding.lo
+    }
+    def "when only one environment previous/next are null"()
+    def "when >= 3 envs, middle envs previous and next are correct"()
+    def "last environment's next is null"()
+
+
     def getApplicationEnvironmentClass(){
         /* ApplicationEnvironmentInjector.primitiveClass */
         return TemplateScriptEngine.createShell().classLoader.loadClass("org.boozallen.plugins.jte.binding.injectors.ApplicationEnvironment")

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
@@ -253,6 +253,24 @@ class ApplicationEnvironmentSpec extends Specification{
             prod.next == null 
     }
 
+    def "defining the previous configuration throws exception"(){
+        when:
+            injectEnvironments([
+                dev: [ previous: "_" ]
+            ])
+        then: 
+            thrown(TemplateConfigException)
+    }
+
+    def "defining the next configuration throws exception"(){
+        when:
+            injectEnvironments([
+                dev: [ next: "_" ]
+            ])
+        then: 
+            thrown(TemplateConfigException)
+    }
+
 
     def getApplicationEnvironmentClass(){
         /* ApplicationEnvironmentInjector.primitiveClass */

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/ApplicationEnvironmentSpec.groovy
@@ -187,16 +187,71 @@ class ApplicationEnvironmentSpec extends Specification{
             assert ex.message == "Variable dev is reserved as an Application Environment." 
     }
 
-    def "first environment's previous is null"{
+    def "first environment's previous is null"(){
+        when: 
+            injectEnvironments([
+                dev: [ long_name: "Development" ],
+                test: [ long_name: "Test" ]
+            ])
+        then: 
+            binding.getVariable("dev").previous == null 
+    }
+    
+    def "second env's previous is correct"(){
+        when: 
+            injectEnvironments([
+                dev: [ long_name: "Development" ],
+                test: [ long_name: "Test" ]
+            ])
+        then: 
+            binding.getVariable("test").previous == binding.getVariable("dev")
+    }
+
+    def "first env's next is correct"(){
+        when: 
+            injectEnvironments([
+                dev: [ long_name: "Development" ],
+                test: [ long_name: "Test" ]
+            ])
+        then: 
+            binding.getVariable("dev").next == binding.getVariable("test")
+    }
+
+    def "when only one environment previous/next are null"(){
         when: 
             injectEnvironments([
                 dev: [ long_name: "Development" ]
             ])
-            binding.lo
+            def dev = binding.getVariable("dev")
+        then: 
+            dev.previous == null
+            dev.next == null 
     }
-    def "when only one environment previous/next are null"()
-    def "when >= 3 envs, middle envs previous and next are correct"()
-    def "last environment's next is null"()
+
+    def "when >= 3 envs, middle envs previous and next are correct"(){
+        when: 
+            injectEnvironments([
+                dev: [ long_name: "Development" ],
+                test: [ long_name: "Test" ],
+                prod: [ long_name: "Production" ]
+            ])
+            def test = binding.getVariable("test")
+        then: 
+            test.previous == binding.getVariable("dev")
+            test.next == binding.getVariable("prod")
+    }
+
+    def "last environment's next is null"(){
+        when: 
+            injectEnvironments([
+                    dev: [ long_name: "Development" ],
+                    test: [ long_name: "Test" ],
+                    prod: [ long_name: "Production" ]
+                ])
+            def prod = binding.getVariable("prod")
+        then: 
+            prod.next == null 
+    }
 
 
     def getApplicationEnvironmentClass(){


### PR DESCRIPTION
# PR Details

Application Environment primitives can now determine the previous and next Application Environment via ``.next`` and ``.previous`` 

## Description

add next and previous properties to ApplicationEnvironment and update the injector to populate these properties during initialization 

## How Has This Been Tested

Unit Test coverage

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
