### PR TITLE
allow stages to pass parameters down to their steps

### DIFF
--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/Stage.groovy
@@ -41,11 +41,11 @@ class Stage extends TemplatePrimitive implements Serializable{
         this.steps = steps 
     }
 
-    void call(){
+    void call(Object... args){
         TemplateLogger.print "[Stage - ${name}]" 
         for(def i = 0; i < steps.size(); i++){
             String step = steps.get(i)
-            InvokerHelper.getMetaClass(script).invokeMethod(script, step, null)
+            InvokerHelper.getMetaClass(script).invokeMethod(script, step, args)
         }
     }
 

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/Stage.groovy
@@ -16,6 +16,7 @@
 
 package org.boozallen.plugins.jte.binding.injectors
 
+import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.config.*
 import org.boozallen.plugins.jte.utils.TemplateScriptEngine
 import org.boozallen.plugins.jte.binding.*
@@ -54,12 +55,20 @@ class Stage extends TemplatePrimitive implements Serializable{
 
         for(def i = 0; i < steps.size(); i++){
             String step = steps.get(i)
-            def impl = script.getBinding().getStep(step)?.impl
-            def metaClass = InvokerHelper.getMetaClass(impl)
-            metaClass.getStageContext = {-> stageContext}
+            setStageContext(step, stageContext)
             InvokerHelper.getMetaClass(script).invokeMethod(script, step, null)
-            metaClass.getStageContext = {-> EMPTY_CONTEXT}
+            setStageContext(step, EMPTY_CONTEXT)
         }
+    }
+
+    @NonCPS
+    private void setStageContext(String step, stageContext) {
+        if(!script.getBinding().hasStep(step)) {
+            return
+        }
+        def impl = script.getBinding().getStep(step)?.impl
+        def metaClass = InvokerHelper.getMetaClass(impl)
+        metaClass.getStageContext = {-> stageContext}
     }
 
     void throwPreLockException(){

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
@@ -80,8 +80,8 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
             ]
             try{
                 Hooks.invoke(BeforeStep, script.getBinding(), context)
-                TemplateLogger.print "[Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]" 
-                result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, methodName, args) 
+                TemplateLogger.print "[Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]"
+                result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, methodName, args)
             } catch (Exception x) {
                 script.currentBuild.result = "Failure"
                 throw new InvokerInvocationException(x)
@@ -131,8 +131,8 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
     static StepWrapper createFromString(String stepText, CpsScript script, String name, String library, Map libConfig){
         Script impl = TemplateScriptEngine.parse(stepText, script.getBinding())
         impl.metaClass."get${StepWrapper.libraryConfigVariable.capitalize()}" << { return libConfig }
+        impl.metaClass.getStageContext = {->  [ name: null, args: [:] ]}
         return new StepWrapper(script: script, impl: impl, name: name, library: library) 
     }
 
 }
-

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/StageSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/StageSpec.groovy
@@ -140,13 +140,22 @@ class StageSpec extends Specification{
             import org.boozallen.plugins.jte.binding.TemplateBinding
             import org.boozallen.plugins.jte.binding.injectors.StageInjector
             import org.boozallen.plugins.jte.config.TemplateConfigObject
+            import org.boozallen.plugins.jte.binding.injectors.LibraryLoader
 
+            def StepWrapper = LibraryLoader.getPrimitiveClass()
+            
             /*
                 initialize
             */
-            setBinding(new TemplateBinding())
-            a = { arg1 -> println "running step A: " + arg1 }
-            b = { println "running step B" }
+            def binding = new TemplateBinding()
+            setBinding(binding)
+          
+          
+            a = StepWrapper.createFromString('''def call() { println "running step A: " + stageContext.args.text }''', 
+                this, 'a', 'test', [:])
+            b = StepWrapper.createFromString('''def call() { println "running step B: " + stageContext.args.text2 }''', 
+                this, 'b', 'test', [:])
+                                           
             TemplateConfigObject config = new TemplateConfigObject(config: [
                 stages: [
                     test_stage: [
@@ -158,13 +167,13 @@ class StageSpec extends Specification{
             StageInjector.doInject(config, this)
 
             // run stage
-            test_stage("Example")
+            test_stage([text: "Example", text2: "Example2"])
 
             """, false))
             def build =  jenkins.buildAndAssertSuccess(job)
             expect:
             jenkins.assertLogContains("running step A: Example", build)
-            jenkins.assertLogContains("running step B", build)
+            jenkins.assertLogContains("running step B: Example2", build)
 
     }
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Stages will now pass any arguments to the stages defined within, for example a deployment stage that can contain multiple steps can be re-used with an application environment so that steps can be dynamic based on the environment passed in

See: https://github.com/linead/jte-testing/tree/master/stages-with-envs for a simple example of a stage with behaviour based on stages

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Initial testing via unit tests
- Manual testing via a dockerised jenkins instance running jenkins 2.164.3 with the following repos
  - https://github.com/linead/jte-testing/tree/master/stages-with-envs
  - https://github.com/linead/jte-jobs

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Not sure about labels to add to the PR, but can update the documentation to reflect this if the code changes look fine

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
