### PR TITLE
Fix hook serialization error

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/binding/TemplatePrimitiveInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/TemplatePrimitiveInjector.groovy
@@ -40,7 +40,7 @@ abstract class TemplatePrimitiveInjector implements ExtensionPoint{
 
         // used to get all injectors
         static ExtensionList<TemplatePrimitiveInjector> all(){
-            return Jenkins.getActiveInstance().getExtensionList(TemplatePrimitiveInjector)
+            return Jenkins.get().getExtensionList(TemplatePrimitiveInjector)
         }
     }
 }

--- a/src/main/resources/org/boozallen/plugins/jte/hooks/Hooks.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/hooks/Hooks.groovy
@@ -16,8 +16,9 @@
 
 package org.boozallen.plugins.jte.hooks
 
+import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.utils.TemplateScriptEngine
-import org.boozallen.plugins.jte.binding.* 
+import org.boozallen.plugins.jte.binding.*
 import org.boozallen.plugins.jte.binding.injectors.LibraryLoader
 import java.lang.annotation.Annotation
 import jenkins.model.Jenkins
@@ -25,6 +26,7 @@ import org.boozallen.plugins.jte.console.TemplateLogger
 
 class Hooks implements Serializable{
 
+    @NonCPS
     static List<AnnotatedMethod> discover(Class<? extends Annotation> hookType, TemplateBinding binding){
         List<AnnotatedMethod> discovered = new ArrayList() 
 


### PR DESCRIPTION
# PR Details

We came across #26 when we upgraded to 1.3 after facing a more intermittent issue in 1.1.1 with serialization. 

I tried a few different things to expose this via testing but I couldn't work out exactly how to make jenkins serialize the method at the right point. 

## Description

The hooks class is now marked as NonCPS when it discovers the hooks to avoid line 39 trying to serialize a method object which fails due to it being not serializable.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We've run a patched version of 1.3 with NonCPS and it resolved the issue. Our pipeline includes a class utilising hooks as well as stages and libraries.


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
