### PR TITLE
JDK 11 Support - fixes issue #28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = 'org.jenkins-ci.plugins'
-version = '1.4' 
+version = '1.4.1' 
 description = 'Allows users to create tool-agnostic, templated pipelines to be shared by multiple teams' 
 
 jenkinsPlugin {

--- a/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
@@ -70,10 +70,21 @@ class TemplateScriptEngine implements Serializable{
     static Class parseClass(String classText){
         GroovyClassLoader classLoader = createShell().getClassLoader()
         GroovyClassLoader tempLoader = new GroovyClassLoader(classLoader)
+        /*
+            Creating a new, short-lived class loader that inherits the
+            compiler configuration of the pipeline's is the easiest 
+            way to parse a file and see if the class has been loaded
+            before
+        */
         Class clazz = tempLoader.parseClass(classText)
-        if(!classLoader.getClassCacheEntry(clazz.getName())){
-            classLoader.setClassCacheEntry(clazz)
+        Class returnClass = clazz 
+        if(classLoader.getClassCacheEntry(clazz.getName())){
+            // class has been loaded before. fetch and return 
+            returnClass = classLoader.loadClass(clazz.getName())
+        } else {
+            // class has not be parsed before, add to the runs class loader
+            classLoader.setClassCacheEntry(returnClass)
         }
-        return clazz 
+        return returnClass 
     }
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
@@ -16,7 +16,6 @@
 
 package org.boozallen.plugins.jte.utils
 
-import org.boozallen.plugins.jte.console.TemplateLogger
 import java.lang.reflect.Field
 import org.boozallen.plugins.jte.binding.TemplateBinding
 import org.codehaus.groovy.control.CompilerConfiguration

--- a/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/utils/TemplateScriptEngine.groovy
@@ -16,6 +16,7 @@
 
 package org.boozallen.plugins.jte.utils
 
+import org.boozallen.plugins.jte.console.TemplateLogger
 import java.lang.reflect.Field
 import org.boozallen.plugins.jte.binding.TemplateBinding
 import org.codehaus.groovy.control.CompilerConfiguration
@@ -65,15 +66,14 @@ class TemplateScriptEngine implements Serializable{
         return script 
     }
 
+
     static Class parseClass(String classText){
-        GroovyShell shell = createShell() 
-        try{
-            Class clazz = shell.getClassLoader().parseClass(classText)
-            shell.getClassLoader().setClassCacheEntry(clazz)
-            return clazz 
-        }catch(LinkageError ex){
-            String className = ex.getMessage().split(" ").last().replaceAll("/",".").replaceAll('"',"")
-            return shell.getClassLoader().loadClass(className)
+        GroovyClassLoader classLoader = createShell().getClassLoader()
+        GroovyClassLoader tempLoader = new GroovyClassLoader(classLoader)
+        Class clazz = tempLoader.parseClass(classText)
+        if(!classLoader.getClassCacheEntry(clazz.getName())){
+            classLoader.setClassCacheEntry(clazz)
         }
+        return clazz 
     }
 }


### PR DESCRIPTION
# PR Details

The exception message thrown by LinkageError when the same class is parsed twice changed between JDK 8 and JDK 11.  This implements as much cleaner way of handling this case. 

## Description

Stop interpreting the LinkageError exception message and actually check the class loader's class cache. 

## How Has This Been Tested

All unit tests pass and manually tested against jenkins/jenkins:lts and jenkins/jenkins:lts-jdk11

## Types of Changes

- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
