### PR TITLE
Fix hyphenated blocks in config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = 'org.jenkins-ci.plugins'
-version = '1.4.1' 
+version = '1.4.2' 
 description = 'Allows users to create tool-agnostic, templated pipelines to be shared by multiple teams' 
 
 jenkinsPlugin {

--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
@@ -110,10 +110,11 @@ class TemplateConfigDsl implements Serializable{
     String tab = "    "
     block.each{ key, value -> 
       if(value instanceof Map){
+        String nodeName = key.contains("-") ? "'${key}'" : key
         if (value == [:]){
-          file += "${tab*depth}${key}"
+          file += "${tab*depth}${nodeName}{}"
         }else{
-          file += "${tab*depth}${key}{"
+          file += "${tab*depth}${nodeName}{"
           depth++
           file = printBlock(file, depth, value)
           depth-- 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
@@ -272,4 +272,32 @@ class TemplateConfigDslSpec extends Specification {
             reparsedConfig.getConfig() == expectedConfig
     }
 
+    def "Double Quote String block keys with hyphens are appropriately serialized"(){
+        setup: 
+            String config = "\"some-block\"{}"
+            Map expectedConfig = [ "some-block": [:] ]
+            def originalConfig, reparsedConfig
+        when: 
+            originalConfig = TemplateConfigDsl.parse(config)
+            reparsedConfig = TemplateConfigDsl.parse(TemplateConfigDsl.serialize(originalConfig))
+            println TemplateConfigDsl.serialize(originalConfig)
+        then: 
+            originalConfig.getConfig() == expectedConfig
+            reparsedConfig.getConfig() == expectedConfig
+    }
+
+    def "Single Quote String block keys with hyphens are appropriately serialized"(){
+        setup: 
+            String config = "'some-block'{}"
+            Map expectedConfig = [ "some-block": [:] ]
+            def originalConfig, reparsedConfig
+        when: 
+            originalConfig = TemplateConfigDsl.parse(config)
+            reparsedConfig = TemplateConfigDsl.parse(TemplateConfigDsl.serialize(originalConfig))
+            println TemplateConfigDsl.serialize(originalConfig)
+        then: 
+            originalConfig.getConfig() == expectedConfig
+            reparsedConfig.getConfig() == expectedConfig
+    }
+
 }


### PR DESCRIPTION
# PR Details

String block names in the ``pipeline_config.groovy`` file that included hyphens were incorrectly serialized resulting in a sandbox exception being thrown. 

For example, 

~~~
"some-block"{ }
~~~

resulted in 

~~~
Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.boozallen.plugins.jte.config.TemplateConfigBuilder$BuilderMethod minus org.boozallen.plugins.jte.config.TemplateConfigBuilder$BuilderMethod). Administrators can decide whether to approve or reject this signature.
[Pipeline] End of Pipeline
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.boozallen.plugins.jte.config.TemplateConfigBuilder$BuilderMethod minus org.boozallen.plugins.jte.config.TemplateConfigBuilder$BuilderMethod)
~~~

and then after approving the accidental jenkins security sandbox exception,
~~~
java.lang.SecurityException: 
        onMethodCall:
        invoker -> org.kohsuke.groovy.sandbox.impl.Checker$1@320245d
        receiver -> PROPERTY_MISSING
        method -> invokeMethod
        args -> [minus, [PROPERTY_MISSING]]
~~~ 



## Description

fixed TemplateConfigDsl.serialize method

## How Has This Been Tested

Unit tests added for these cases, testing against an actual Jenkins instance.

## Types of Changes

- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
