### PR TITLE
use annotations for merge and override flags

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/config/PipelineConfig.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/PipelineConfig.groovy
@@ -69,14 +69,21 @@ class PipelineConfig implements Serializable{
       }
 
       currentConfigObject.override.each{ key ->
-        if (get_prop(child.config, key)){
+        if (get_prop(child.config, key) != null){
           clear_prop(pipeline_config, key)
-          get_prop(pipeline_config, key) << get_prop(child.config, key) 
+
+          if(get_prop(pipeline_config, key) instanceof Map){
+            get_prop(pipeline_config, key) << get_prop(child.config, key)
+          } else { 
+            def newValue = get_prop(child.config, key)
+            set_prop(pipeline_config, key, newValue)
+          }
+          
         }
       }
 
       currentConfigObject.merge.each{ key ->
-        if (get_prop(child.config, key)){
+        if (get_prop(child.config, key) != null){
           get_prop(pipeline_config, key) << (get_prop(child.config, key) + get_prop(pipeline_config, key))
         }
       }
@@ -103,6 +110,21 @@ class PipelineConfig implements Serializable{
       p.tokenize('.').inject(o){ obj, prop ->    
         if (prop.equals(last_token) && InvokerHelper.getMetaClass(obj?."$prop").respondsTo(obj?."$prop", "clear", (Object[]) null)){
           obj?."$prop".clear()
+        }
+        obj?."$prop"
+      }   
+    }
+
+    static void set_prop(o, p, n){
+      def last_token
+      if (p.tokenize('.')){
+        last_token = p.tokenize('.').last()
+      } else if (InvokerHelper.getMetaClass(o).respondsTo(o, "clear", (Object[]) null)){
+        o = n 
+      }
+      p.tokenize('.').inject(o){ obj, prop ->    
+        if (prop.equals(last_token)){
+          obj?."$prop" = n 
         }
         obj?."$prop"
       }   
@@ -142,60 +164,91 @@ class PipelineConfig implements Serializable{
     }
 
     static printJoin(TemplateConfigObject outcome, TemplateConfigObject incoming, TemplateConfigObject prev){
-        def data = [outcome:[c:outcome, nestedKeys:[]],
-                    incoming:[c:incoming, nestedKeys:[]],
-                    prev:[c:prev, nestedKeys:[]]]
+
+        // flatten each configuration for ease of delta analysis 
+        def fOutcome = getNested(outcome.getConfig())
+        def fIncoming = getNested(incoming.getConfig())
+        def fPrevious = getNested(prev.getConfig())
+
 
         def output = ['Pipeline Configuration Modifications']
 
-        // get the nested keys and data
-        data.each { k, v ->
-            v['nested'] = getNested(v.c.config, v['nestedKeys'])
+        // Determine Configurations Added
+        def configurationsAdded = fOutcome.keySet() - fPrevious.keySet()
+        if (configurationsAdded){
+          output << "Configurations Added:" 
+          configurationsAdded.each{ key -> 
+            output << "- ${key} set to ${fOutcome[key]}"
+          }
+        }else{
+          output << "Configurations Added: None" 
         }
 
-        // get the added keys
-        def keys = (data.incoming.nestedKeys - data.prev.nestedKeys).intersect(data.outcome.nestedKeys)
-        output << "Configurations Added:${keys.empty? ' None': '' }"
-        keys.each{ k ->
-            output << "- ${k} set to ${data.outcome.nested[k]}"
+        // Determine Configurations Deleted
+        def configurationsDeleted = (fPrevious - fOutcome).keySet().findAll{ !(it in fOutcome.keySet()) }
+        if (configurationsDeleted){
+          output << "Configurations Deleted:" 
+          configurationsDeleted.each{ key -> 
+            output << "- ${key}"
+          }
+        }else{
+          output << "Configurations Deleted: None" 
+        }
+        // Determine Configurations Changed 
+        def configurationsChanged = (fOutcome - fPrevious).findAll{ it.getKey() in fPrevious.keySet() }
+        if (configurationsChanged){
+          output << "Configurations Changed:" 
+          configurationsChanged.keySet().each{ key  -> 
+            output << "- ${key} changed from ${fPrevious[key]} to ${fOutcome[key]}"
+          }
+        }else{
+          output << "Configurations Changed: None" 
         }
 
-        def changeKeys = data.incoming.nestedKeys.intersect(data.prev.nestedKeys)
-
-        keys = changeKeys.findAll{ k -> data.prev.nested[k] != data.incoming.nested[k] }
-        def overriddenChangedKeys = keys.findAll({k -> data.prev.c.override.find({ 1 == (k.toString() - it).count(".")})})
-        def notOverriddenChangedKeys = keys - overriddenChangedKeys
-
-        output << "Configurations Changed:${overriddenChangedKeys.empty? ' None': '' }"
-        overriddenChangedKeys.each{ k ->
-            output << "- ${k} changed from ${data.prev.nested[k]} to ${data.outcome.nested[k]}"
+        // Determine Configurations Duplicated
+        def configurationsDuplicated = fPrevious.intersect(fIncoming)
+        if (configurationsDuplicated){
+          output << "Configurations Duplicated:" 
+          configurationsDuplicated.keySet().each{ key -> 
+            output << "- ${key}"
+          }
+        }else{
+          output << "Configurations Duplicated: None" 
         }
 
-        keys = changeKeys.findAll{ k -> data.prev.nested[k] == data.incoming.nested[k] }
-        output << "Configurations Duplicated:${keys.empty? ' None': '' }"
-        keys.each{ k ->
-          output << "- ${k} duplicated with ${data.prev.nested[k]}"
+        // Determine Configurations Ignored 
+        def configurationsIgnored = (fIncoming - fOutcome).keySet()
+        if (configurationsIgnored){
+          output << "Configurations Ignored:" 
+          configurationsIgnored.each{ key -> 
+            output << "- ${key}"
+          }
+        }else{
+          output << "Configurations Ignored: None" 
+        }
+        
+        // Print Subsequent May Merge
+        def subsequentMayMerge = outcome.merge 
+        if(subsequentMayMerge){
+          output << "Subsequent May Merge:"
+          subsequentMayMerge.each{ key -> 
+            output << "- ${key}" 
+          }
+        }else{
+          output << "Subsequent May Merge: None" 
         }
 
-        keys = (data.incoming.nestedKeys - data.outcome.nestedKeys)
-        output << "Configurations Ignored:${(notOverriddenChangedKeys + keys).empty? ' None': '' }"
-        keys.each{ k ->
-            output << "- ${k}"
-        }
-        notOverriddenChangedKeys.each{ k ->
-            output << "- ${k} ignored change from ${data.prev.nested[k]} to ${data.incoming.nested[k]}"
-        }
-
-
-        output << "Subsequent may merge:${data.outcome.c.merge.empty? ' None': '' }"
-        data.outcome.c.merge.each{ k ->
-            output << "- ${k}"
+        // Print Subsequent May Override 
+        def subsequentMayOverride = outcome.override 
+        if(subsequentMayOverride){
+          output << "Subsequent May Override:"
+          subsequentMayOverride.each{ key -> 
+            output << "- ${key}" 
+          }
+        }else{
+          output << "Subsequent May Override: None" 
         }
 
-        output << "Subsequent may override:${data.outcome.c.override.empty? ' None': '' }"
-        data.outcome.c.override.each{ k ->
-            output << "- ${k}"
-        }
 
         TemplateLogger.print( output.join("\n"), [ initiallyHidden: true, trimLines: false ])
     }

--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
@@ -48,6 +48,9 @@ class TemplateConfigDsl implements Serializable{
     cc.scriptBaseClass = TemplateConfigBuilder.class.name
     
     GroovyShell sh = new GroovyShell(TemplateConfigDsl.classLoader, our_binding, cc);
+
+    script_text = script_text.replaceAll("@merge", "builderMerge();")
+    script_text = script_text.replaceAll("@override", "builderOverride();")
     
     TemplateConfigDslSandbox sandbox = new TemplateConfigDslSandbox()
     sandbox.register();
@@ -63,70 +66,38 @@ class TemplateConfigDsl implements Serializable{
   static String serialize(TemplateConfigObject configObj){
     Map config = new JsonSlurper().parseText(JsonOutput.toJson(configObj.getConfig()))
 
-    // inserts merge keys into config Map for printing 
-    configObj.merge.each{ merge -> 
-      if (!merge){
-        config.merge = true 
-      }
-      def last_token
-      if (merge.tokenize('.')){
-        last_token = merge.tokenize('.').last()
-      }
-      merge.tokenize('.').inject(config){ obj, prop ->
-        if (prop.equals(last_token)){
-          obj."${prop}".merge = true 
-          return obj 
-        }else{
-          return obj."${prop}" 
-        }
-      } 
-    }
-
-    // inserts override keys into config Map for printing 
-    configObj.override.each{ override -> 
-      def last_token
-      if (!override){
-        config.override = true 
-      }
-      if (override.tokenize('.')){
-        last_token = override.tokenize('.').last()
-      }
-      override.tokenize('.').inject(config){ obj, prop ->
-        if (prop.equals(last_token)){
-          obj."${prop}".override = true 
-          return obj 
-        }else{
-          return obj."${prop}" 
-        }
-      }
-    }  
-
     def depth = 0
     ArrayList file = [] 
-    return printBlock(file, depth, config).join("\n")
+    ArrayList keys = []
+    return printBlock(file, depth, config, keys, configObj).join("\n")
   }
 
-  static ArrayList printBlock(ArrayList file, depth, Map block){
+  static ArrayList printBlock(ArrayList file, depth, Map block, ArrayList keys, TemplateConfigObject configObj){
     String tab = "    "
     block.each{ key, value -> 
+      String coordinate = keys.size() ? "${keys.join(".")}.${key}" : key 
+      String merge = (coordinate in configObj.merge) ? "@merge " : "" 
+      String override = (coordinate in configObj.override) ? "@override " : "" 
       if(value instanceof Map){
         String nodeName = key.contains("-") ? "'${key}'" : key
         if (value == [:]){
-          file += "${tab*depth}${nodeName}{}"
+          file += "${tab*depth}${merge}${override}${nodeName}{}"
         }else{
-          file += "${tab*depth}${nodeName}{"
+          file += "${tab*depth}${merge}${override}${nodeName}{"
           depth++
-          file = printBlock(file, depth, value)
+          keys.push(key)
+          file = printBlock(file, depth, value, keys, configObj)
+          keys.pop()
           depth-- 
           file += "${tab*depth}}"
         }
       }else{
         if (value instanceof String){
-          file += "${tab*depth}${key} = '${StringEscapeUtils.escapeJava(value)}'"
+          file += "${tab*depth}${merge}${override}${key} = '${StringEscapeUtils.escapeJava(value)}'"
         } else if (value instanceof ArrayList){
-          file += "${tab*depth}${key} = ${value.inspect()}" 
+          file += "${tab*depth}${merge}${override}${key} = ${value.inspect()}" 
         }else{
-          file += "${tab*depth}${key} = ${value}" 
+          file += "${tab*depth}${merge}${override}${key} = ${value}" 
         }
       }
     }

--- a/src/test/groovy/org/boozallen/plugins/jte/config/PipelineConfigSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/PipelineConfigSpec.groovy
@@ -22,6 +22,7 @@ import org.junit.ClassRule
 import org.jvnet.hudson.test.GroovyJenkinsRule
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.IgnoreRest
 
 class PipelineConfigSpec extends Specification {
     @Shared
@@ -29,11 +30,13 @@ class PipelineConfigSpec extends Specification {
     @SuppressWarnings('JUnitPublicField')
     public GroovyJenkinsRule groovyJenkinsRule = new GroovyJenkinsRule()
 
-    @Shared
-    public String basePipelineConfig = null
+    @Shared public String basePipelineConfig = null
+    @Shared public def basePipelineConfigMap = null
 
-    @Shared
-    public def basePipelineConfigMap = null
+    public PrintStream logger = Mock()
+    public logs = [] 
+
+    
 
     def setupSpec(){
         basePipelineConfig = PipelineConfig.baseConfigContentsFromLoader(groovyJenkinsRule.jenkins.getPluginManager()
@@ -43,10 +46,10 @@ class PipelineConfigSpec extends Specification {
     }
 
     def setup(){
-        // this caused other test classes to fail
-        templateLoggerSetup()
-    }
+        GroovyMock(TemplateLogger, global:true)
 
+        _ * TemplateLogger.print(_, _) >> { s, c -> logs.push(s) }
+    }
 
     def 'Join empty TemplateConfigObjects to PipelineConfig'(){
         setup:
@@ -78,16 +81,16 @@ class PipelineConfigSpec extends Specification {
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         when:
         TemplateConfigObject configObject = combine(c1)
 
         then:
         configObject.config == (basePipelineConfigMap + [
-                a: 3,
-                b: "hi",
-                c: true
+            a: 3,
+            b: "hi",
+            c: true
         ])
         configObject.merge.isEmpty()
         configObject.override.isEmpty()
@@ -100,19 +103,19 @@ class PipelineConfigSpec extends Specification {
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         String c2 = """
             a = 4
-            """
+        """
         when:
         TemplateConfigObject configObject = combine(c1, c2)
 
         then:
         configObject.config.equals(basePipelineConfigMap + [
-                a: 3,
-                b: "hi",
-                c: true
+            a: 3,
+            b: "hi",
+            c: true
         ])
         configObject.merge.isEmpty()
         configObject.override.isEmpty()
@@ -123,35 +126,36 @@ class PipelineConfigSpec extends Specification {
 
         String c1 = """
             application_environments{ 
-            dev {
-              override = true
-              long_name = 'Dev'
-            }
+                @override dev {
+                    long_name = 'Dev'
+                }
             }
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         String c2 = """
             a = 4
             application_environments{ 
-            dev {
-              long_name = 'Develop'
+                dev {
+                    long_name = 'Develop'
+                }
             }
-            }
-            """
+        """
         when:
         TemplateConfigObject configObject = combine(c1, c2)
 
         then:// while the override occurs, the final result has not overrides
         configObject.config == (basePipelineConfigMap + [
-                application_environments:[
-                dev:[long_name:'Develop']
-                ],
-                a: 3,
-                b: "hi",
-                c: true
+            application_environments:[
+                dev:[
+                    long_name:'Develop'
+                ]
+            ],
+            a: 3,
+            b: "hi",
+            c: true
         ])
         configObject.merge.isEmpty()
         configObject.override.isEmpty()
@@ -162,31 +166,30 @@ class PipelineConfigSpec extends Specification {
 
         String c1 = """
             application_environments{ 
-            dev {
-              override = true
-              long_name = 'Dev'
-            }
+                @override dev {
+                    long_name = 'Dev'
+                }
             }
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         String c2 = """
             a = 4
             application_environments{ 
-            dev {
-              long_name = 'Develop'
+                dev {
+                    long_name = 'Develop'
+                }
             }
-            }
-            """
+        """
 
         String c3 = """
             a = 5
             application_environments{ 
-            dev {
-              long_name = 'Development'
-            }
+                dev {
+                    long_name = 'Development'
+                }
             }
             """
         when:
@@ -194,12 +197,14 @@ class PipelineConfigSpec extends Specification {
 
         then:// override and merge only apply to the next level
         configObject.config == (basePipelineConfigMap + ([
-                application_environments:[
-                        dev:[long_name:'Develop']
-                ],
-                a: 3,
-                b: "hi",
-                c: true
+            application_environments:[
+                dev:[
+                    long_name:'Develop'
+                ]
+            ],
+            a: 3,
+            b: "hi",
+            c: true
         ] as LinkedHashMap))
         configObject.merge.isEmpty()
         configObject.override.isEmpty()
@@ -210,32 +215,31 @@ class PipelineConfigSpec extends Specification {
 
         String c1 = """
             application_environments{ 
-            dev {
-              override = true
-              names {
-                Develop
-                Development
-                Dev
-                dev
-                devel
-                develop
-                development
-              }
-              long_name = 'Dev'
-            }
+                @override dev {
+                    names {
+                        Develop
+                        Development
+                        Dev
+                        dev
+                        devel
+                        develop
+                        development
+                    }
+                    long_name = 'Dev'
+                }
             }
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         String c2 = """
             a = 4
             application_environments{ 
-            dev {
-              long_name = 'Develop'
-              names
-            }
+                dev {
+                    long_name = 'Develop'
+                    names
+                }
             }
             """
         when:
@@ -243,12 +247,15 @@ class PipelineConfigSpec extends Specification {
 
         then:// while the override occurs, the final result has not overrides
         configObject.config == (basePipelineConfigMap + [
-                application_environments:[
-                        dev:[long_name:'Develop', names:[:]]
-                ],
-                a: 3,
-                b: "hi",
-                c: true
+            application_environments:[
+                dev:[
+                    long_name:'Develop', 
+                    names:[:]
+                ]
+            ],
+            a: 3,
+            b: "hi",
+            c: true
         ])
         configObject.merge.isEmpty()
         configObject.override.isEmpty()
@@ -259,49 +266,59 @@ class PipelineConfigSpec extends Specification {
 
         String c1 = """
             application_environments{ 
-            dev {
-              override = true
-              names 
-              long_name = 'Dev'
-            }
+                @override dev {
+                    names 
+                    long_name = 'Dev'
+                }
             }
             a = 3
             b = "hi" 
             c = true 
-            """
+        """
 
         String c2 = """
             a = 4
             application_environments{ 
-            dev {
-              long_name = 'Develop'
-              names {
-                Develop {
-                  merge = true
-                  name = 'Develop'
+                dev {
+                    long_name = 'Develop'
+                    names {
+                        @merge Develop {
+                            name = 'Develop'
+                        }
+                        Development
+                        Dev
+                        dev
+                        devel
+                        develop
+                        development
+                    }
                 }
-                Development
-                Dev
-                dev
-                devel
-                develop
-                development
-              }
             }
-            }
-            """
+        """
         when:
         TemplateConfigObject configObject = combine(c1, c2)
 
         then:// while the override occurs, the final result has not overrides
         configObject.config == (basePipelineConfigMap + [
-                application_environments:[
-                        dev:[long_name:'Develop', names:[Develop: [name:'Develop'],Development:[:],
-                        Dev:[:],dev:[:],devel:[:],develop:[:],development:[:]]]
-                ],
-                a: 3,
-                b: "hi",
-                c: true
+            application_environments:[
+                dev:[
+                    long_name:'Develop',
+                    names:[
+                        Develop: [
+                            name:'Develop'
+                        ],
+                        Development:[:],
+                        Dev:[:],
+                        dev:[:],
+                        devel:[:],
+                        develop:[:],
+                        development:[:]
+                    ]
+                ]
+            ],
+            a: 3,
+            b: "hi",
+            c: true
         ])
         !configObject.merge.isEmpty()
         (['application_environments.dev.names.Develop'] as Set).equals(configObject.merge)
@@ -317,19 +334,21 @@ class PipelineConfigSpec extends Specification {
         p.join(new TemplateConfigObject(config:[b:0, a:1]))
 
         then:
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- a set to 1") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- b set to 0") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated:\n- a duplicated with 1") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
+        assert logs[0].contains("Configurations Added:\n- a set to 1")
+        assert logs[0].contains("Configurations Deleted: None")
+        assert logs[0].contains("Configurations Changed: None")
+        assert logs[0].contains("Configurations Duplicated: None")
+        assert logs[0].contains("Configurations Ignored: None")
+        assert logs[0].contains("Subsequent May Merge: None")
+        assert logs[0].contains("Subsequent May Override: None")
 
+        assert logs[1].contains("Configurations Added:\n- b set to 0")
+        assert logs[1].contains("Configurations Deleted: None")
+        assert logs[1].contains("Configurations Changed: None")
+        assert logs[1].contains("Configurations Duplicated:\n- a")
+        assert logs[1].contains("Configurations Ignored: None")
+        assert logs[1].contains("Subsequent May Merge: None")
+        assert logs[1].contains("Subsequent May Override: None")
     }
 
     def 'printJoin add'(){
@@ -339,26 +358,18 @@ class PipelineConfigSpec extends Specification {
         when:
         p.join(new TemplateConfigObject(config:[a:1]))
         p.join(new TemplateConfigObject(config:[b:0]))
-
-        then:
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- a set to 1") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- b set to 0") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
-
+        
+        then: 
+        assert logs[0].contains("Configurations Added:\n- a set to 1")
+        assert logs[1].contains("Configurations Added:\n- b set to 0")
+        assert logs.findAll{ it.contains('Configurations Duplicated: None') }.size() == 2
+        assert logs.findAll{ it.contains('Configurations Ignored: None') }.size() == 2
+        assert logs.findAll{ it.contains('Subsequent May Merge: None') }.size() == 2
+        assert logs.findAll{ it.contains('Subsequent May Override: None') }.size() == 2
     }
 
     def 'printJoin failed change'(){
         setup:
-
         PipelineConfig p = new PipelineConfig(TemplateConfigDsl.parse(basePipelineConfig))
         TemplateConfigObject t = new TemplateConfigObject(config:[a:[b:1]])
 
@@ -367,69 +378,115 @@ class PipelineConfigSpec extends Specification {
         p.join(new TemplateConfigObject(config:[a:[b:2]]))
 
         then:
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- a.b set to 1") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
-        1 * TemplateLogger.print({it.contains("Configurations Added: None") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored:\n" +
-                        "- a.b ignored change from 1 to 2") &&
-                it.contains("Subsequent may merge: None")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
+        assert logs[0].contains('Configurations Added:\n- a.b set to 1')
+        assert logs[0].contains("Configurations Deleted: None")
+        assert logs[0].contains('Configurations Changed: None')
+        assert logs[0].contains('Configurations Duplicated: None')
+        assert logs[0].contains('Configurations Ignored: None') 
+        assert logs[0].contains('Subsequent May Merge: None') 
+        assert logs[0].contains('Subsequent May Override: None') 
+
+        assert logs[1].contains('Configurations Added: None') 
+        assert logs[1].contains("Configurations Deleted: None")
+        assert logs[1].contains('Configurations Changed: None')
+        assert logs[1].contains('Configurations Duplicated: None')
+        assert logs[1].contains('Configurations Ignored:\n- a.b')        
+        assert logs[1].contains('Subsequent May Merge: None') 
+        assert logs[1].contains('Subsequent May Override: None') 
+
 
     }
 
     def 'printJoin change'(){
         setup:
-
-
         PipelineConfig p = new PipelineConfig(TemplateConfigDsl.parse(basePipelineConfig))
         TemplateConfigObject t = new TemplateConfigObject(config:[a:1])
 
         when:
         TemplateConfigObject configObject = combine("""
-a{
-  b = 1
-  override = true
-}
-""", """
-a{
-  b = 2
-  override = true
-}
-""")
+        @override a{
+            b = 1
+        }
+        """, """
+        a{
+            b = 2
+        }
+        """)
 
         then:
-        1 * TemplateLogger.print({it.contains("Configurations Added:\n- a.b set to 1") &&
-                it.contains("Configurations Changed: None") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None") &&
-                it.contains("Subsequent may override:\n- a")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
-        1 * TemplateLogger.print({it.contains("Configurations Added: None") &&
-                it.contains("Configurations Changed:\n" +
-                        "- a.b changed from 1 to 2") &&
-                it.contains("Configurations Duplicated: None") &&
-                it.contains("Configurations Ignored: None") &&
-                it.contains("Subsequent may merge: None") &&
-                it.contains("Subsequent may override:\n- a")
-        }, _) >> { s, c -> return System.out.print(s + "\n") }
+        assert logs[0].contains("Configurations Added:\n- a.b set to 1")
+        assert logs[0].contains("Configurations Deleted: None")
+        assert logs[0].contains('Configurations Duplicated: None')
+        assert logs[0].contains('Configurations Ignored: None') 
+        assert logs[0].contains('Subsequent May Merge: None') 
+        assert logs[0].contains('Subsequent May Override:\n- a') 
 
+        assert logs[1].contains('Configurations Added: None') 
+        assert logs[0].contains("Configurations Deleted: None")
+        assert logs[1].contains("Configurations Changed:\n- a.b changed from 1 to 2")
     }
+
+    def 'override root key'(){
+        setup: 
+        PipelineConfig p = new PipelineConfig(TemplateConfigDsl.parse(basePipelineConfig))
+        
+        when: 
+        p.join(TemplateConfigDsl.parse("@override a = 1"))
+        p.join(TemplateConfigDsl.parse("a = 2"))
+
+        then: 
+        assert p.config.config.a == 2 
+    }
+
+    def 'override nested key'(){
+        setup: 
+        PipelineConfig p = new PipelineConfig(TemplateConfigDsl.parse(basePipelineConfig))
+        
+        when: 
+        p.join(TemplateConfigDsl.parse("""
+            a{ 
+                @override y = true
+                x = true 
+            }
+        """))
+        p.join(TemplateConfigDsl.parse("""
+            a{ 
+                y = false 
+            }
+        """))
+
+        then: 
+        assert p.config.config.a.y == false 
+        assert p.config.config.a.x == true  
+    }
+
+    def 'printJoin configuration Deleted'(){
+        setup: 
+        PipelineConfig p = new PipelineConfig(TemplateConfigDsl.parse(basePipelineConfig))
+        
+        when: 
+        p.join(TemplateConfigDsl.parse("""
+            @override a{ 
+                y = true
+                x = true 
+            }
+        """))
+        p.join(TemplateConfigDsl.parse("""
+            a{ 
+                y = false 
+            }
+        """))
+
+        then: 
+        assert p.config.config.a == [ y: false ]
+        assert logs[1].contains("Configurations Deleted:\n- a.x")
+    }
+
 
     /*
     helpers
      */
 
-    void templateLoggerSetup(){
-        GroovySpy(TemplateLogger, global: true)
-        TemplateLogger.print(_, _) >> { s, c -> return System.out.print(s) }
-    }
 
     // helper
     TemplateConfigObject combine(String ... configs){

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
@@ -90,9 +90,7 @@ class TemplateConfigDslSpec extends Specification {
     def 'One Merge First Key'(){
         setup: 
             String config = """
-            application_environments{
-                merge = true
-            } 
+            @merge application_environments
             """
         when: 
             TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
@@ -104,9 +102,7 @@ class TemplateConfigDslSpec extends Specification {
         setup: 
             String config = """
             application_environments{
-                dev{
-                    merge = true
-                }
+                @merge dev
             } 
             """
         when: 
@@ -119,12 +115,8 @@ class TemplateConfigDslSpec extends Specification {
         setup: 
             String config = """
             application_environments{
-                dev{
-                    merge = true
-                }
-                test{
-                    merge = true 
-                }
+                @merge dev
+                @merge test
             } 
             """
         when: 
@@ -136,9 +128,7 @@ class TemplateConfigDslSpec extends Specification {
     def 'One Override First Key'(){
         when: 
             String config = """
-            application_environments{
-                override = true
-            } 
+            @override application_environments
             """
             TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
         then: 
@@ -149,9 +139,7 @@ class TemplateConfigDslSpec extends Specification {
         when: 
             String config = """
             application_environments{
-                dev{
-                    override = true
-                }
+                @override dev
             } 
             """
             TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
@@ -163,12 +151,8 @@ class TemplateConfigDslSpec extends Specification {
         setup: 
             String config = """
             application_environments{
-                dev{
-                    override = true
-                }
-                test{
-                    override = true 
-                }
+                @override dev
+                @override test
             } 
             """
         when: 
@@ -212,26 +196,6 @@ class TemplateConfigDslSpec extends Specification {
             TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
         then: 
             configObject.getConfig() == [ field: [:] ]
-    }
-
-    def "merge key when not true is not added to list"(){
-        setup:
-            String config = "a{ merge = false }"
-        when: 
-            TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
-        then: 
-            configObject.getConfig() == [ a: [ merge: false ] ]
-            configObject.merge == [] as Set
-    }
-
-    def "override key when not true is not added to list"(){
-        setup:
-            String config = "a{ override = false }"
-        when: 
-            TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
-        then: 
-            configObject.getConfig() == [ a: [ override: false ] ]
-            configObject.override == [] as Set
     }
 
     def "syntax validation for unquoted values"(){


### PR DESCRIPTION
# PR Details

Leverage annotations for specifying which configuration blocks **or keys** should be marked as mergeable or overridable by the next pipeline configuration. 

## Description

Instead of allowing merge or override at the block level, switch to ``@merge`` and ``@override`` annotations that can be used on either blocks or keys. 

I was also having a hard time wrapping my head around the configuration modification logging.  I rewrote it to be a little clearer and added a **Configurations Deleted** section to the output. 

This new functionality changes the existing syntax from: 

~~~
application_environments{
  merge = true 
  dev
}
~~~

to 
~~~
@merge application_environments{
  dev
}
~~~

and **adds** the functionality of: 

~~~
libraries{
  owasp_zap{
      @override url = "https://example.com"
      threshold = 10 
  }
}
~~~

## How Has This Been Tested

Unit testing updated to reflect new syntax and add in support for new use cases. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
