### PR TITLE
Remove unused 'application' Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
   id 'org.jenkins-ci.jpi' version '0.27.0'
   id 'jacoco' 
-  id 'application'
 }
 
 repositories {


### PR DESCRIPTION
Otherwise `gradle build` fails as follows:
> No value has been specified for property 'mainClassName'.