### PR TITLE
allow pipeline configuration files to reference 'env' variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 bin
 build
-docs/_build
+docs/html
 .settings
 .project
 .classpath
@@ -10,3 +10,4 @@ docs/_build
 .scannerwork/
 target/
 .DS_Store
+node_modules

--- a/docs/modules/pipeline-templating/pages/configuration_files.adoc
+++ b/docs/modules/pipeline-templating/pages/configuration_files.adoc
@@ -86,3 +86,23 @@ template_methods{
     functional_test
 }
 ----
+
+== Environment Substitutions 
+
+In Jenkins, environment variables are made accessible via the ``env`` global variable.  This variable is resolvable within your pipeline configuration file. 
+
+This also means that Build Parameters can be access within the pipeline configuration file as they are stored on the ``env`` variable. 
+
+For example, in the following configuration:  
+
+.pipeline_config.groovy
+[source, groovy]
+---- 
+libraries{
+    someLibrary{
+        someField = env.buildParam ?: "default if not set" 
+    }
+}
+----
+
+``libraries.someLibrary.someField`` would resolve to the Build Parameter named ``buildParam`` and would default to ``default if not set`` if ``buildParam`` was not truthy. 

--- a/src/main/groovy/org/boozallen/plugins/jte/TemplateEntryPointVariable.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/TemplateEntryPointVariable.groovy
@@ -63,12 +63,12 @@ import javax.annotation.Nonnull
             // aggregate the pipeline configurations
             PipelineConfig pipelineConfig = newPipelineConfig()
             aggregateTemplateConfigurations(pipelineConfig)
-            binding.setVariable("pipelineConfig", pipelineConfig.getConfig().getConfig())
-            binding.setVariable("templateConfigObject", pipelineConfig.getConfig())
 
             // prepare the template environment by populating the binding
             Binding binding = newTemplateBinding()
             script.setBinding(binding)
+            binding.setVariable("pipelineConfig", pipelineConfig.getConfig().getConfig())
+            binding.setVariable("templateConfigObject", pipelineConfig.getConfig())
             initializeBinding(pipelineConfig, script)
 
             // parse entrypoint and return 

--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDsl.groovy
@@ -16,11 +16,14 @@
 
 package org.boozallen.plugins.jte.config
 
+import org.boozallen.plugins.jte.utils.RunUtils
 import org.apache.commons.lang.StringEscapeUtils
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.kohsuke.groovy.sandbox.SandboxTransformer
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 /*
   Parses an Template Config File and returns a TemplateConfigObject
@@ -40,19 +43,24 @@ class TemplateConfigDsl implements Serializable{
   static TemplateConfigObject parse(String script_text){
 
     TemplateConfigObject templateConfig = new TemplateConfigObject()
-    
-    Binding our_binding = new Binding(templateConfig: templateConfig)
+    EnvActionImpl env = getEnvironment()
+
+    Binding our_binding = new Binding(
+      templateConfig: templateConfig,
+      env: env 
+    )
     
     CompilerConfiguration cc = new CompilerConfiguration()
     cc.addCompilationCustomizers(new SandboxTransformer())
     cc.scriptBaseClass = TemplateConfigBuilder.class.name
     
-    GroovyShell sh = new GroovyShell(TemplateConfigDsl.classLoader, our_binding, cc);
-    
-    TemplateConfigDslSandbox sandbox = new TemplateConfigDslSandbox()
+    GroovyShell sh = new GroovyShell(our_binding, cc);
+    Script script = sh.parse(script_text)
+
+    TemplateConfigDslSandbox sandbox = new TemplateConfigDslSandbox(script, env)
     sandbox.register();
     try {
-      sh.evaluate script_text
+      script.run()
     }finally {
       sandbox.unregister();
     }
@@ -134,6 +142,11 @@ class TemplateConfigDsl implements Serializable{
       }
     }
     return file 
+  }
+
+  // for unit testing
+  private static EnvActionImpl getEnvironment(){
+    return EnvActionImpl.forRun(RunUtils.getRun())
   }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSandbox.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSandbox.groovy
@@ -18,6 +18,7 @@ package org.boozallen.plugins.jte.config
 
 import org.kohsuke.groovy.sandbox.GroovyInterceptor
 import org.kohsuke.groovy.sandbox.GroovyInterceptor.Invoker
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
 
 /*
   our sandbox.  just block all the things except the creation of
@@ -27,9 +28,18 @@ import org.kohsuke.groovy.sandbox.GroovyInterceptor.Invoker
   so backed off to checking if it's a Script object. 
 */
 class TemplateConfigDslSandbox extends GroovyInterceptor {
+
+  Script script 
+  EnvActionImpl env
+
+  TemplateConfigDslSandbox(Script script, EnvActionImpl env){
+    this.script = script 
+    this.env = env 
+  }
+
   @Override
   Object onMethodCall(Invoker invoker, Object receiver, String method, Object... args) throws Throwable {
-    if (!(receiver in TemplateConfigBuilder)){
+    if (!(receiver == script)){
       throw new SecurityException("""
         onMethodCall:
         invoker -> ${invoker}
@@ -54,7 +64,7 @@ class TemplateConfigDslSandbox extends GroovyInterceptor {
   
   @Override
   public Object onNewInstance(Invoker invoker, Class receiver, Object... args) throws Throwable {
-    if (!(receiver in TemplateConfigBuilder)){
+    if (!(receiver == script)){
       throw new SecurityException("""
         onNewInstance:
         invoker -> ${invoker}
@@ -66,7 +76,7 @@ class TemplateConfigDslSandbox extends GroovyInterceptor {
 
   @Override
   public void onSuperConstructor(Invoker invoker, Class receiver, Object... args) throws Throwable {
-    if (!(receiver in TemplateConfigBuilder)){
+    if (!(receiver == script)){
       throw new SecurityException("""
         onSuperConstructor:
         invoker -> ${invoker}
@@ -90,7 +100,7 @@ class TemplateConfigDslSandbox extends GroovyInterceptor {
 
   @Override
   public Object onGetProperty(Invoker invoker, Object receiver, String property) throws Throwable {
-    if (!(receiver in TemplateConfigBuilder)){
+    if (!(receiver == script || receiver == env)){
       throw new SecurityException("""
         onGetProperty:
         invoker -> ${invoker}
@@ -103,7 +113,7 @@ class TemplateConfigDslSandbox extends GroovyInterceptor {
 
   @Override
   public Object onSetProperty(Invoker invoker, Object receiver, String property, Object value) throws Throwable {
-    if (!(receiver in TemplateConfigBuilder)){
+    if (!(receiver == script)){
       throw new SecurityException("""
         onSetProperty:
         invoker -> ${invoker}

--- a/src/main/groovy/org/boozallen/plugins/jte/utils/RunUtils.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/utils/RunUtils.groovy
@@ -58,18 +58,20 @@ class RunUtils implements Serializable{
         PrintStream logger = listener.getLogger()
         return logger
     }
-   
-    static WorkflowJob getJob(){
-        FlowExecutionOwner owner = getOwner()
 
+    static WorkflowRun getRun(){
+        FlowExecutionOwner owner = getOwner()
         Queue.Executable exec = owner.getExecutable()
         if (!(exec instanceof WorkflowRun)) {
             throw new IllegalStateException("Must be run from a WorkflowRun, found: ${exec.getClass()}")
         }
-
-        WorkflowRun build = (WorkflowRun) exec
-        WorkflowJob job = build.getParent()
-
+        WorkflowRun run = (WorkflowRun) exec
+        return run 
+    }
+   
+    static WorkflowJob getJob(){
+        WorkflowRun run = getRun() 
+        WorkflowJob job = run.getParent()
         return job
     }
 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/GovernanceTierSpec.groovy
@@ -22,6 +22,7 @@ import org.junit.Rule
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl
 import com.cloudbees.hudson.plugins.folder.Folder
 import jenkins.plugins.git.GitSampleRepoRule
 import hudson.plugins.git.GitSCM
@@ -74,6 +75,10 @@ class GovernanceTierSpec extends Specification{
         // create tier 2 
         List<ScmLibraryProvider> librarySources2 = [] 
         tier2 = new GovernanceTier(scm, baseDir2, librarySources2)
+
+        // mock run
+        GroovySpy(TemplateConfigDsl, global:true)
+        _ * TemplateConfigDsl.getEnvironment() >> GroovyMock(EnvActionImpl)
     }
 
     // test baseDir is root of repository 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/PipelineConfigSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/PipelineConfigSpec.groovy
@@ -23,6 +23,7 @@ import org.jvnet.hudson.test.GroovyJenkinsRule
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.IgnoreRest
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
 
 class PipelineConfigSpec extends Specification {
     @Shared
@@ -36,18 +37,17 @@ class PipelineConfigSpec extends Specification {
     public PrintStream logger = Mock()
     public logs = [] 
 
-    
+    def setup(){
 
-    def setupSpec(){
-        basePipelineConfig = PipelineConfig.baseConfigContentsFromLoader(groovyJenkinsRule.jenkins.getPluginManager()
-                .uberClassLoader)
+        basePipelineConfig = PipelineConfig.baseConfigContentsFromLoader(groovyJenkinsRule.jenkins.getPluginManager().uberClassLoader)
+
+        // mock run
+        GroovySpy(TemplateConfigDsl, global:true)
+        _ * TemplateConfigDsl.getEnvironment() >> GroovyMock(EnvActionImpl)
 
         basePipelineConfigMap = TemplateConfigDsl.parse(basePipelineConfig).config
-    }
 
-    def setup(){
         GroovyMock(TemplateLogger, global:true)
-
         _ * TemplateLogger.print(_, _) >> { s, c -> logs.push(s) }
     }
 

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateConfigDslSpec.groovy
@@ -17,18 +17,42 @@
 package org.boozallen.plugins.jte.config
 
 import spock.lang.*
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
 
 class TemplateConfigDslSpec extends Specification {
 
+    def setup(){
+        EnvActionImpl env = Mock() 
+        env.getProperty("someField") >> "envProperty" 
+
+        GroovySpy(TemplateConfigDsl, global:true)
+        TemplateConfigDsl.getEnvironment() >> env 
+    }
+
+    def "include Jenkins env var in configuration"(){
+        setup: 
+        String config = "a = env.someField" 
+        
+        when: 
+        TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
+
+        then: 
+        configObject.config == [ a: "envProperty" ]
+        configObject.merge.isEmpty()
+        configObject.override.isEmpty()
+    }
+
     def 'Empty Config File'(){
         setup: 
-            String config = "" 
+        String config = "" 
+
         when: 
-            TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
+        TemplateConfigObject configObject = TemplateConfigDsl.parse(config)
+        
         then: 
-            configObject.config == [:]
-            configObject.merge.isEmpty()
-            configObject.override.isEmpty()
+        configObject.config == [:]
+        configObject.merge.isEmpty()
+        configObject.override.isEmpty()
     }
 
     def 'Flat Keys Configuration'(){

--- a/src/test/groovy/org/boozallen/plugins/jte/config/TemplateEntryPointVariableSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/TemplateEntryPointVariableSpec.groovy
@@ -27,6 +27,7 @@ import org.jvnet.hudson.test.GroovyJenkinsRule
 import org.jvnet.hudson.test.WithoutJenkins
 import spock.lang.Shared
 import spock.lang.Specification
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
 
 
 class TemplateEntryPointVariableSpec extends Specification {
@@ -35,12 +36,10 @@ class TemplateEntryPointVariableSpec extends Specification {
     @SuppressWarnings('JUnitPublicField')
     public GroovyJenkinsRule groovyJenkinsRule = new GroovyJenkinsRule()
 
-    def setupSpec(){
-
-    }
-
     def setup(){
         templateLoggerSetup()
+        GroovySpy(TemplateConfigDsl, global:true)
+        _ * TemplateConfigDsl.getEnvironment() >> GroovyMock(EnvActionImpl)
     }
 
     @WithoutJenkins

--- a/src/test/groovy/org/boozallen/plugins/jte/config/libraries/ScmLibraryProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/config/libraries/ScmLibraryProviderSpec.groovy
@@ -19,6 +19,7 @@ import org.boozallen.plugins.jte.binding.injectors.StepWrapper
 import org.boozallen.plugins.jte.binding.TemplateBinding
 import org.boozallen.plugins.jte.console.TemplateLogger
 import org.boozallen.plugins.jte.utils.RunUtils
+import org.boozallen.plugins.jte.config.TemplateConfigDsl
 
 import spock.lang.*
 import org.junit.Rule
@@ -33,6 +34,7 @@ import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.WithoutJenkins
 import org.jvnet.hudson.test.BuildWatcher
 import org.jenkinsci.plugins.workflow.cps.CpsScript
+import org.jenkinsci.plugins.workflow.cps.EnvActionImpl 
 
 class ScmLibraryProviderSpec extends Specification{
 
@@ -59,6 +61,9 @@ class ScmLibraryProviderSpec extends Specification{
         _ * RunUtils.getJob() >> job
         GroovyMock(TemplateLogger, global:true)
         _ * TemplateLogger.print(_,_)
+
+        GroovySpy(TemplateConfigDsl, global:true)
+        _ * TemplateConfigDsl.getEnvironment() >> GroovyMock(EnvActionImpl)
 
 
         repo.init()


### PR DESCRIPTION
# PR Details

resolves #49 

## Description

Updated the ``TemplateConfigDsl.parse`` method to include the ``EnvActionImpl`` made available to pipeline's via the ``env`` variable. 

This means that any Jenkins environment variables that have been defined, or Build Parameters, will now be resolvable in pipeline configuration files. 

## How Has This Been Tested

Unit tests && integration testing 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
