### PR TITLE
Added missing import

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
@@ -19,6 +19,7 @@ package org.boozallen.plugins.jte.job
 import org.boozallen.plugins.jte.config.GovernanceTier
 import hudson.Extension
 import jenkins.branch.MultiBranchProject
+import org.boozallen.plugins.jte.config.ScmPipelineConfigurationProvider
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.kohsuke.stapler.DataBoundConstructor
 import org.kohsuke.stapler.DataBoundSetter


### PR DESCRIPTION
# PR Details

Fixed missing import

## Description

Fixed the missing ScmPipelineConfigurationProvider import in the TemplateBranchProjectFactory class

## How Has This Been Tested

- Created a docker container:
```
docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 jenkins/jenkins:2.226-jdk11
```
- Built the JPI:
```
make jpi
```
- Copied the hpi file to /var/jenkins_home/plugins using `docker cp`
- Tested that the "Exclude branches without a pipeline configuration file" was working by scanning the multibranch.
- Ran unit tests

## Types of Changes

- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [X] All new and existing tests passed.
