### PR TITLE
Do not set currentBuild.result to success at the beginning of the build

### DIFF
--- a/docs/modules/library-development/pages/lifecycle_hooks.adoc
+++ b/docs/modules/library-development/pages/lifecycle_hooks.adoc
@@ -32,9 +32,12 @@ The following lifecycle hook annotations are available:
 
 == Implementation
 
-In order to write a pipeline step leveraging one of these lifecycle hooks, you must annotate the step with the annotation and accept a context input parameter to the method.
+Lifecycle Hook annotations can be placed on any method inside a step. Hooks must accept a `context` parameter that is of type `HookContext` from the JTE plugin.  Because of Groovy's ducktyping functionality, you do not have to declare the Class of the context parameter. 
 
-This context parameter provides context so that the step can vary its behavior based on what just happened in the pipeline.
+[NOTE]
+====
+You can name the input parameter whatever you want to.  For ease of communication, it is assumed the parameter is named `context`
+====
 
 .JTE LifeCycle Hook Context Parameter
 |===
@@ -46,28 +49,20 @@ This context parameter provides context so that the step can vary its behavior b
 | `context.step`
 | The name of the Step associated with the hook
 
-| `context.status`
-| The current pipeline build status
- 
 |===
 
 [IMPORTANT]
 ====
-`context.library` and `context.step` will be `null` before and after pipeline execution and are only to be leveraged by `@BeforeStep`, `@AfterStep`, and `@Notify`
-====
-
-[NOTE]
-====
-The reference to the variable name `context` makes the assumption that you've named the input parameter to the step with the hook annotation `context`.  In practice, this variable name can be whatever you please
+`context.library` and `context.step` will be `null` before and after pipeline execution due to the fact that the hook is not in response to a particular pipeline step. 
 ====
 
 == Conditional Execution
 
 Sometimes you'll only want to invoke the Hook when certain conditions are met, such as a build failure or in relation to another step (like before static code analysis).
 
-Each annotation accepts a `Closure` parameter.  If the return object of this closure is `*true <http://www.groovy-lang.org/semantics.html#Groovy-Truth>*` then the hook will be executed.
+Each annotation accepts a `Closure` parameter.  If the return object of this closure is http://www.groovy-lang.org/semantics.html#Groovy-Truth[truthy] then the hook will be executed.
 
-While executing, the code within the `Closure` will be able to resolve the `context` variable described above as well as the library configuration variable `config`.
+While executing, the code within the `Closure` parameter will be able to resolve the `context` variable described, the library configuration of the library that loads the step via the `config` variable, and the `currentBuild` variable made available in Jenkins Pipelines. 
 
 Example Syntax:
 
@@ -75,16 +70,14 @@ Example Syntax:
 ----
 @BeforeStep({ context.step.equals("build") })
 void call(context){
-    /*
-        execute something right before the library step called
-        build is executed.
-    */
+    // execute something right before the library step called build is executed.
 }
 ----
 
 [IMPORTANT]
 ====
-The closure parameter is optional. If omitted, the hook will always be executed.
+* The closure parameter is optional. If omitted, the hook will always be executed.
+* The `context` variable is always called `context` within the Closure parameter, regardless of what the step's input parameter is named. 
 ====
 
 == Example Implementation
@@ -124,9 +117,7 @@ We must remember to annotate the method and pass the step a context input parame
 
 [source,groovy]
 ----
-@AfterStep({
-    context.step.equals("build") && context.status.equals("FAILURE")
-})
+@AfterStep({ context.step.equals("build") })
 void call(context){
     slackSend color: '#ff0000', message: "Build Failure: ${env.JOB_URL}"
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/hooks/HookContext.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/hooks/HookContext.groovy
@@ -27,5 +27,4 @@ package org.boozallen.plugins.jte.hooks
 class HookContext implements Serializable{
     String library 
     String step 
-    Object[] args = []
 }   

--- a/src/main/groovy/org/boozallen/plugins/jte/hooks/HookContext.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/hooks/HookContext.groovy
@@ -1,0 +1,31 @@
+/*
+   Copyright 2018 Booz Allen Hamilton
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.boozallen.plugins.jte.hooks
+
+/*
+    stores contextual information a hook might need to 
+    respond accordingly. 
+
+    step: the step that's triggering the hook 
+    library: library that contributed the step triggering the hook
+    args: any arguments passed to the step triggering the hook
+*/
+class HookContext implements Serializable{
+    String library 
+    String step 
+    Object[] args = []
+}   

--- a/src/main/resources/org/boozallen/plugins/jte/TemplateEntryPoint.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/TemplateEntryPoint.groovy
@@ -32,20 +32,9 @@ def call(CpsClosure body = null){
         template = TemplateEntryPointVariable.getTemplate(pipelineConfig)
     }
 
-    // otherwise currentBuild.result defaults to null 
-    currentBuild.result = "SUCCESS"
-    Map context = [
-        step: null, 
-        library: null, 
-        status: currentBuild.result 
-    ]
-
     try{
-        // execute methods in steps annotated @Validate
-        Hooks.invoke(Validate, getBinding(), context)
-
-        // execute methods in steps annotated @Init
-        Hooks.invoke(Init, getBinding(), context)
+        Hooks.invoke(Validate, getBinding())
+        Hooks.invoke(Init, getBinding())
         
         /*
           exists if JTE invoked via:
@@ -60,14 +49,9 @@ def call(CpsClosure body = null){
         }
     }catch(any){
         currentBuild.result = "FAILURE" 
-        context.status = currentBuild.result 
         throw any 
     }finally{
-        /*
-          execute methods in steps annotated with @CleanUp
-          followed by @Notify
-        */
-        Hooks.invoke(CleanUp, getBinding(), context)
-        Hooks.invoke(Notify, getBinding(), context)
+        Hooks.invoke(CleanUp, getBinding())
+        Hooks.invoke(Notify, getBinding())
     }
 }

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
@@ -78,8 +78,7 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
             def result
             HookContext context = new HookContext(
                 step: name, 
-                library: library,
-                args: args
+                library: library
             )
             TemplateBinding binding = script.getBinding()
             try{

--- a/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/binding/injectors/StepWrapper.groovy
@@ -76,22 +76,22 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
     def invoke(String methodName, Object... args){
         if(InvokerHelper.getMetaClass(impl).respondsTo(impl, methodName, args)){
             def result
-            def context = [
+            HookContext context = new HookContext(
                 step: name, 
                 library: library,
-                status: script.currentBuild.result
-            ]
+                args: args
+            )
+            TemplateBinding binding = script.getBinding()
             try{
-                Hooks.invoke(BeforeStep, script.getBinding(), context)
+                Hooks.invoke(BeforeStep, binding, context)
                 TemplateLogger.print "[Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]"
                 result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, methodName, args)
             } catch (Exception x) {
                 script.currentBuild.result = "Failure"
                 throw new InvokerInvocationException(x)
             } finally{
-                context.status = script.currentBuild.result
-                Hooks.invoke(AfterStep, script.getBinding(), context)
-                Hooks.invoke(Notify, script.getBinding(), context)
+                Hooks.invoke(AfterStep, binding, context)
+                Hooks.invoke(Notify, binding, context)
             }
             return result 
         }else{

--- a/src/main/resources/org/boozallen/plugins/jte/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/hooks/AnnotatedMethod.groovy
@@ -35,7 +35,7 @@ class AnnotatedMethod implements Serializable{
         this.stepWrapper = stepWrapper 
     } 
 
-    void invoke(Map context){
+    void invoke(HookContext context){
         try{
             String lib = stepWrapper.library
             String step = stepWrapper.name 

--- a/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/StepWrapperSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/binding/injectors/StepWrapperSpec.groovy
@@ -284,7 +284,7 @@ class StepWrapperSpec extends Specification{
             createStep("test_step", "def call(){ println 'testing' }")
             createStep("test_step2", """
             @BeforeStep
-            def call(Map Context){ 
+            def call(context){ 
                 println "before!" 
             }
             """)
@@ -305,10 +305,9 @@ class StepWrapperSpec extends Specification{
     def "@AfterStep executes after step"(){
         when: 
             createStep("test_step", "def call(){ println 'testing' }")
-            createStep("test_step2", """
-            
+            createStep("test_step2", """            
             @AfterStep
-            def call(Map Context){ 
+            def call(context){ 
                 println "after!" 
             }
             """)
@@ -331,7 +330,7 @@ class StepWrapperSpec extends Specification{
             createStep("test_step", "def call(){ println 'testing' }")
             createStep("test_step2", """
             @Notify
-            def call(Map Context){ 
+            def call(context){ 
                 println "notify!" 
             }
             """)


### PR DESCRIPTION
# PR Details

In order to fix #74, the `currentBuild.result` is no longer automatically set to `SUCCESS` at the beginning of a JTE pipeline run. 

In resolving this, the `context` parameter passed to Lifecycle Hooks no longer requires the build status to be set.  This result has been removed from context parameters due to the fact that the `currentBuild` variable can be accessed to fetch the same information. 

This `currentBuild` variable, not specific to JTE, has also been made resolvable within Lifecycle Hook's optional Closure parameter that determines whether or not the hook should be executed. 

## Description

* Stop setting `currentBuild.result = SUCCESS` in TemplateEntryPoint 
* Remove `context.status` from the Lifecycle Hook's context parameter
* Convert the context parameter to a dedicated `HookContext` class instead of a generic Map.  Just a cleaner way to do it :). 

## How Has This Been Tested

Unit Tests and manual testing 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
