### PR TITLE
restart working

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
@@ -115,12 +115,12 @@ class GroovyShellDecoratorImpl extends GroovyShellDecorator {
                     */
                     BlockStatement wrapper = (new AstBuilder().buildFromCode(CompilePhase.SEMANTIC_ANALYSIS){
                         try{
-                            Hooks.invoke(Validate, this.getBinding())
-                            Hooks.invoke(Init, this.getBinding())
+                            Hooks.invoke(Validate)
+                            Hooks.invoke(Init)
                             // <-- this is where the template AST statements get injected
                         }finally{
-                            Hooks.invoke(CleanUp, this.getBinding())
-                            Hooks.invoke(Notify, this.getBinding())
+                            Hooks.invoke(CleanUp)
+                            Hooks.invoke(Notify)
                         }
                     }).first()
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -16,6 +16,7 @@
 package org.boozallen.plugins.jte.init.governance.libs
 
 import hudson.Extension
+import hudson.FilePath
 import hudson.model.Descriptor
 import hudson.model.DescriptorVisibilityFilter
 import jenkins.model.Jenkins
@@ -118,7 +119,9 @@ class PluginLibraryProvider extends LibraryProvider{
         // load steps
         StepWrapperFactory stepFactory = new StepWrapperFactory(flowOwner)
         libraries[libName].steps.each{ stepName, stepContents ->
-            def s = stepFactory.createFromString(stepContents, script, stepName, libName, libConfig)
+            FilePath stepFile = new FilePath(flowOwner.getRootDir()).child("jte/${libName}/${stepName}.groovy")
+            stepFile.write(stepContents, "UTF-8")
+            def s = stepFactory.createFromFilePath(stepFile, binding, libName, libConfig)
             binding.setVariable(stepName, s)
         }
         return libConfigErrors

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
@@ -16,6 +16,7 @@
 package org.boozallen.plugins.jte.init.governance.libs
 
 import hudson.Extension
+import hudson.FilePath
 import hudson.Util
 import hudson.scm.SCM
 import jenkins.scm.api.SCMFile
@@ -84,8 +85,11 @@ class ScmLibraryProvider extends LibraryProvider{
         lib.children().findAll{
             it.getName().endsWith(".groovy") &&
             !it.getName().endsWith("library_config.groovy") // exclude lib config file
-        }.each{ stepFile ->
-            def s = stepFactory.createFromFile(stepFile, libName, binding, libConfig)
+        }.each{ scmFile ->
+            FilePath rootDir = new FilePath(flowOwner.getRootDir())
+            FilePath stepFile = rootDir.child("jte/${libName}/${scmFile.getName()}")
+            stepFile.write(scmFile.contentAsString(), "UTF-8")
+            def s = stepFactory.createFromFilePath(stepFile, binding, libName, libConfig)
             binding.setVariable(s.getName(), s)
         }
 

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
@@ -16,7 +16,6 @@
 
 package org.boozallen.plugins.jte.init.primitives.hooks
 
-import org.boozallen.plugins.jte.binding.*
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.codehaus.groovy.runtime.InvokerInvocationException

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -17,12 +17,18 @@
 package org.boozallen.plugins.jte.init.primitives.injectors
 
 import com.cloudbees.groovy.cps.NonCPS
+import hudson.FilePath
+import org.boozallen.plugins.jte.init.PipelineDecorator
+import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.hooks.*
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.codehaus.groovy.runtime.InvokerInvocationException
+import org.jenkinsci.plugins.workflow.cps.CpsThread
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 /*
     represents a library step. 
@@ -33,17 +39,88 @@ import org.codehaus.groovy.runtime.InvokerInvocationException
     2. To provide a means to do LifeCycle Hooks before/after step execution
 */
 class StepWrapper extends TemplatePrimitive implements Serializable{
-    private Object impl
-    private Binding binding
+    /**
+     * The name of the step
+     */
     private String name
-    private String library 
 
+    /**
+     * The name of the library that's contributed the step
+     */
+    private String library
+
+    /**
+     * The library configuration
+     */
+    private LinkedHashMap config
+
+    /**
+     * The FilePath where the source text for this
+     * library step can be found
+     */
+    private String sourceFile
+
+    /**
+     * Alternatively, store the source text in a variable.
+     *   e.g. NullStep's and Default Step Implementation
+     */
+    private String sourceText
+
+    /**
+     * A caching of the parsed source text used during invocation
+     */
+    private transient Object impl
+
+    @NonCPS String getName(){ return name }
+    @NonCPS String getLibrary(){ return library }
+
+    /*
+     * memoized getter.
+     * impl will be null:
+     *  1. prior to first invocation
+     *  2. after a pipeline is resumed following an ungraceful shut down
+     */
+    @NonCPS Object getImpl(){
+        if(!impl){
+            impl = parseSource()
+        }
+        return impl
+    }
+    /*
+
+    */
     @NonCPS
-    String getName(){ return name }
-    
-    @NonCPS
-    String getLibrary(){ return library }
-    
+    private Object parseSource(){
+        CpsThread thread = CpsThread.current()
+        if(!thread){
+            throw new IllegalStateException("CpsThread not present.")
+        }
+
+        FlowExecutionOwner flowOwner = thread.getExecution().getOwner()
+        WorkflowRun run = flowOwner.run()
+        PipelineDecorator pipelineDecorator = run.getAction(PipelineDecorator)
+        if(!pipelineDecorator){
+            throw new IllegalStateException("PipelineDecorator action missing")
+        }
+        TemplateBinding binding = pipelineDecorator.getBinding()
+
+        String source
+        if(sourceFile){
+            FilePath f = new FilePath(new File(sourceFile))
+            if(f.exists()){
+                source = f.readToString()
+            }else{
+                throw new IllegalStateException("Unable to find source file '${sourceFile}' for StepWrapper[library: ${library}, name: ${name}]")
+            }
+        }else if (sourceText){
+            source = sourceText
+        }else{
+            throw new IllegalStateException("Unable to determine StepWrapper[library: ${library}, name: ${name}] source.")
+        }
+
+        StepWrapperFactory factory = new StepWrapperFactory(flowOwner)
+        return factory.prepareScript(library, name, source, binding, config)
+    }
     /*
         need a call method defined on method missing so that 
         CpsScript recognizes the StepWrapper as something it 
@@ -67,21 +144,21 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
         step implementation script. 
     */
     def invoke(String methodName, Object... args){
-        if(InvokerHelper.getMetaClass(impl).respondsTo(impl, methodName, args)){
+        if(InvokerHelper.getMetaClass(getImpl()).respondsTo(getImpl(), methodName, args)){
             def result
             HookContext context = new HookContext(
                 step: name, 
                 library: library
             )
             try{
-                Hooks.invoke(BeforeStep, binding, context)
+                Hooks.invoke(BeforeStep, context)
                 TemplateLogger.createDuringRun().print "[Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]"
-                result = InvokerHelper.getMetaClass(impl).invokeMethod(impl, methodName, args)
+                result = InvokerHelper.getMetaClass(getImpl()).invokeMethod(getImpl(), methodName, args)
             } catch (Exception x) {
                 throw new InvokerInvocationException(x)
             } finally{
-                Hooks.invoke(AfterStep, binding, context)
-                Hooks.invoke(Notify, binding, context)
+                Hooks.invoke(AfterStep, context)
+                Hooks.invoke(Notify, context)
             }
             return result 
         }else{

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
@@ -13,6 +13,7 @@
 
 package org.boozallen.plugins.jte.init.governance.libs
 
+import hudson.FilePath
 import hudson.model.TaskListener
 import hudson.plugins.git.BranchSpec
 import hudson.plugins.git.GitSCM
@@ -43,7 +44,7 @@ class ScmLibraryProviderSpec extends Specification{
     PrintStream logger = Mock()
 
     def setup(){
-        WorkflowJob job = GroovyMock()
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
         job.asBoolean() >> true
         WorkflowRun run = GroovyMock()
         run.getParent() >> job
@@ -111,16 +112,20 @@ class ScmLibraryProviderSpec extends Specification{
         GitSCM scm = createSCM(repo)
         p.setScm(scm)
 
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        owner.getRootDir() >> new File(f.getRemote())
+
         GroovySpy(StepWrapperFactory, global:true)
         new StepWrapperFactory(_) >> Mock(StepWrapperFactory){
-            createFromFile(*_) >> { args ->
-                String name = args[0].getName() - ".groovy"
+            createFromFilePath(*_) >> { args ->
+                String name = args[0].getBaseName()
                 return new StepWrapper(name)
             }
         }
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
+        fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
         FileSystemWrapper.createFromSCM(owner, scm) >> fsw
 
@@ -144,16 +149,20 @@ class ScmLibraryProviderSpec extends Specification{
         GitSCM scm = createSCM(repo)
         p.setScm(scm)
 
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        owner.getRootDir() >> new File(f.getRemote())
+
         GroovySpy(StepWrapperFactory, global:true)
         new StepWrapperFactory(_) >> Mock(StepWrapperFactory){
-            createFromFile(*_) >> { args ->
-                String name = args[0].getName() - ".groovy"
+            createFromFilePath(*_) >> { args ->
+                String name = args[0].getBaseName()
                 return new StepWrapper(name)
             }
         }
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
+        fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
         FileSystemWrapper.createFromSCM(owner, scm) >> fsw
         
@@ -177,16 +186,20 @@ class ScmLibraryProviderSpec extends Specification{
         GitSCM scm = createSCM(repo)
         p.setScm(scm)
 
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        owner.getRootDir() >> new File(f.getRemote())
+
         GroovySpy(StepWrapperFactory, global:true)
         new StepWrapperFactory(_) >>  Mock(StepWrapperFactory){
-            createFromFile(*_) >> { args ->
-                String name = args[0].getName() - ".groovy"
+            createFromFilePath(*_) >> { args ->
+                String name = args[0].getBaseName()
                 return new StepWrapper(name)
             }
         }
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
+        fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
         FileSystemWrapper.createFromSCM(owner, scm) >> fsw
         


### PR DESCRIPTION
# PR Details

JTE pipelines can survive an ungraceful restart now, which was the impetus for much of the refactoring we’re doing for JTE v2.0.

The source code of a library step gets compiled into a Script object and stored on a StepWrapper.

Previously, we just stored the Script object itself.  for some reason, when jenkins restarts that Script object fails to be executed.  some sort of classloader issue.

so the fix was:
1. vendor the source of the library steps into each build’s directory in JENKINS_HOME
2. set the Script field on StepWrapper to transient so we don’t bother persisting it
3. instead - store a pointer to where the source code for the library step lives
4. memoize the getter for the Script object so that if it’s no longer present (in the event of an ungraceful restart) - we can reparse it from source again.

## Description

Copy library steps into a FilePath in the rootDir of the build and point to the FilePath source for each library step to be able to reparse if for some reason the value of `impl` is lost


