### PR TITLE
Allow config to reverse library precedence

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/LibraryLoader.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/LibraryLoader.groovy
@@ -17,6 +17,7 @@
 package org.boozallen.plugins.jte.binding.injectors
 
 import org.boozallen.plugins.jte.binding.*
+import org.boozallen.plugins.jte.config.TemplateGlobalConfig
 import org.boozallen.plugins.jte.utils.RunUtils
 import org.boozallen.plugins.jte.utils.TemplateScriptEngine
 import org.boozallen.plugins.jte.config.TemplateConfigObject
@@ -38,6 +39,9 @@ import com.cloudbees.groovy.cps.NonCPS
         List<GovernanceTier> tiers = GovernanceTier.getHierarchy() 
         List<LibraryConfiguration> libs = tiers.collect{ it.getLibraries() }.flatten().minus(null)
         List<LibraryProvider> providers = libs.collect{ it.getLibraryProvider() }.flatten().minus(null)
+        if(TemplateGlobalConfig.get().getAllowLibraryOverride()) {
+            providers = providers.reverse();
+        }
 
         ArrayList libConfigErrors = []
         config.getConfig().libraries.each{ libName, libConfig ->
@@ -50,7 +54,7 @@ import com.cloudbees.groovy.cps.NonCPS
         }
         libConfigErrors = libConfigErrors.flatten().minus(null)
         
-        // if library errors were found: 
+        // if library errors were found:
         if(libConfigErrors){
             TemplateLogger.printError("----------------------------------")
             TemplateLogger.printError("   Library Configuration Errors   ")

--- a/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/LibraryLoader.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/binding/injectors/LibraryLoader.groovy
@@ -39,7 +39,7 @@ import com.cloudbees.groovy.cps.NonCPS
         List<GovernanceTier> tiers = GovernanceTier.getHierarchy() 
         List<LibraryConfiguration> libs = tiers.collect{ it.getLibraries() }.flatten().minus(null)
         List<LibraryProvider> providers = libs.collect{ it.getLibraryProvider() }.flatten().minus(null)
-        if(TemplateGlobalConfig.get().getAllowLibraryOverride()) {
+        if(!TemplateGlobalConfig.get().getAllowLibraryOverride()) {
             providers = providers.reverse();
         }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/config/TemplateGlobalConfig.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/config/TemplateGlobalConfig.groovy
@@ -26,6 +26,7 @@ import jenkins.model.GlobalConfiguration
 public class TemplateGlobalConfig extends GlobalConfiguration {
 
     private GovernanceTier tier
+    private Boolean allowLibraryOverride = true;
 
     public static TemplateGlobalConfig get() {
         return GlobalConfiguration.all().get(TemplateGlobalConfig)
@@ -44,4 +45,11 @@ public class TemplateGlobalConfig extends GlobalConfiguration {
         return tier
     }
 
+    Boolean getAllowLibraryOverride() {
+        return allowLibraryOverride
+    }
+
+    void setAllowLibraryOverride(Boolean allowLibraryOverride) {
+        this.allowLibraryOverride = allowLibraryOverride
+    }
 }

--- a/src/main/resources/org/boozallen/plugins/jte/config/TemplateGlobalConfig/config.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/config/TemplateGlobalConfig/config.jelly
@@ -17,6 +17,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:section title="${%Jenkins Templating Engine}">
+        <f:entry title="Allow library override">
+            <f:checkbox field="allowLibraryOverride" checked="${descriptor.libraryOverride}"/>
+        </f:entry>
         <f:entry field="tier" title="">
             <f:property/>
         </f:entry>


### PR DESCRIPTION
# PR Details

Added checkbox in global config to allow disabling of libraries being loaded at a more granular level
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## How Has This Been Tested

Added test as well as manual verification 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
