### PR TITLE
Support Declarative Syntax

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
@@ -50,7 +50,7 @@ import java.lang.reflect.Field
  *
  * @author Steven Terrana
  */
-@Extension
+@Extension(ordinal=1.0D) // set ordinal > 0 so JTE comes before Declarative
 class GroovyShellDecoratorImpl extends GroovyShellDecorator {
 
     /**


### PR DESCRIPTION
# PR Details

This PR sets a > 0 ordinal on JTE's `GroovyShellDecoratorImpl` as part of the effort to support declarative syntax.

According to the `@Extension` [javadocs](https://javadoc.jenkins.io/hudson/Extension.html#ordinal--), extensions with greater ordinal values are listed first. 

This ensures that the JTE compile-time changes take place prior to the compile-time parsing that declarative syntax does. 

For more info, check out the [corresponding pull request on pipeline-model-definition](https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/403)

marking this as a draft.  will wait to see if there are changes on either side (JTE/Declarative) that we want to include to this. 

**Will need to write a page in the documentation that should be included in this PR prior to merging.**