### PR TITLE
Implement StepWrapper Base Class, autowire HookContext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,17 @@ jacocoTestReport {
     }
 }
 
+sourceSets{
+    main{
+        java{
+            srcDirs = [ ]
+        }
+        groovy{
+            srcDirs += [ "src/main/java" ]
+        }
+    }
+}
+
 spotless{
     groovy{
         trimTrailingWhitespace()

--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -395,7 +395,7 @@ ruleset {
     MethodCount
     MethodSize
     NestedBlockDepth
-    ParameterCount
+//    ParameterCount
 
     // rulesets/unnecessary.xml
     AddEmptyString

--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -395,7 +395,7 @@ ruleset {
     MethodCount
     MethodSize
     NestedBlockDepth
-//    ParameterCount
+    ParameterCount
 
     // rulesets/unnecessary.xml
     AddEmptyString

--- a/docs/modules/library-development/pages/lifecycle_hooks.adoc
+++ b/docs/modules/library-development/pages/lifecycle_hooks.adoc
@@ -34,28 +34,25 @@ image::lifecycle_hook.png[Lifecycle Hook Flow Diagram]
 
 == Implementation
 
-Lifecycle Hook annotations can be placed on any method inside a step. Hooks must accept a `context` parameter that is of type `HookContext` from the JTE plugin.  Because of Groovy's ducktyping functionality, you do not have to declare the Class of the context parameter. 
+Lifecycle Hook annotations can be placed on any method inside a step.
 
-[NOTE]
-====
-You can name the input parameter whatever you want to.  For ease of communication, it is assumed the parameter is named `context`
-====
+Every step has an autowired `hookContext` variable which provides steps with relevant information about what triggered the hook.
 
-.JTE LifeCycle Hook Context Parameter
+.JTE LifeCycle Hooks `hookContext` Variable
 |===
 | Variable | Description
 
-| `context.library`
+| `hookContext.library`
 | The name of the Library that contributed the step associated with the hook
 
-| `context.step`
+| `hookContext.step`
 | The name of the Step associated with the hook
 
 |===
 
 [IMPORTANT]
 ====
-`context.library` and `context.step` will be `null` before and after pipeline execution due to the fact that the hook is not in response to a particular pipeline step. 
+`hookContext.library` and `hookContext.step` will be `null` before and after pipeline execution due to the fact that the hook is not in response to a particular pipeline step.
 ====
 
 == Conditional Execution
@@ -64,20 +61,19 @@ Sometimes you'll only want to invoke the Hook when certain conditions are met, s
 
 Each annotation accepts a `Closure` parameter.  If the return object of this closure is http://www.groovy-lang.org/semantics.html#Groovy-Truth[truthy] then the hook will be executed.
 
-While executing, the code within the `Closure` parameter will be able to resolve the `context` variable described, the library configuration of the library that loads the step via the `config` variable, and the `currentBuild` variable made available in Jenkins Pipelines. 
+While executing, the code within the `Closure` parameter will be able to resolve the `hookContext` variable, the library configuration of the library that loads the step via the `config` variable, and the `currentBuild` variable made available in Jenkins Pipelines.
 
 Example Syntax:
 
 [source,groovy]
 ----
-@BeforeStep({ context.step.equals("build") })
-void call(context){
+@BeforeStep({ hookContext.step.equals("build") })
+void call(){
     // execute something right before the library step called build is executed.
 }
 ----
 
 [IMPORTANT]
 ====
-* The closure parameter is optional. If omitted, the hook will always be executed.
-* The `context` variable is always called `context` within the Closure parameter, regardless of what the step's input parameter is named. 
+The closure parameter is optional. If omitted, the hook will always be executed.
 ====

--- a/docs/modules/primitives/pages/stages.adoc
+++ b/docs/modules/primitives/pages/stages.adoc
@@ -25,3 +25,20 @@ and then in your template:
 continuous_integration()
 deploy_to dev
 ----
+
+== Stage Context
+
+It can be helpful for steps to understand if they are being executed as part of a stage and if so, which stage and what parameters, if any, were passed to the stage.
+
+Steps are autowired with a `stageContext` variable that can be used to access this information.
+
+|===
+| Property | Description
+
+| `stageContext.name`
+| The name of the stage being executed. Is `null` if the step is not being executed as part of a stage.
+
+| `stageContext.args`
+| A map of named parameters passed to the stage. Is an empty map if not being executed as part of a stage or if no parameters were passed to the stage.
+
+|===

--- a/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
@@ -88,10 +88,6 @@ class GroovyShellDecoratorImpl extends GroovyShellDecorator {
      */
     @Override
     void configureCompiler(@CheckForNull final CpsFlowExecution execution, CompilerConfiguration cc) {
-        ImportCustomizer ic = new ImportCustomizer()
-        ic.addStarImports("org.boozallen.plugins.jte.init.primitives.hooks")
-        cc.addCompilationCustomizers(ic)
-
         if(isFromJTE(execution)){
             cc.addCompilationCustomizers(new CompilationCustomizer(CompilePhase.SEMANTIC_ANALYSIS) {
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/GroovyShellDecoratorImpl.groovy
@@ -33,7 +33,6 @@ import org.codehaus.groovy.control.CompilePhase
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.control.customizers.CompilationCustomizer
-import org.codehaus.groovy.control.customizers.ImportCustomizer
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/ReservedVariableName.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/ReservedVariableName.groovy
@@ -22,10 +22,6 @@ import jenkins.model.Jenkins
 @SuppressWarnings(['EmptyMethodInAbstractClass'])
 abstract class ReservedVariableName implements ExtensionPoint{
 
-    static String getName(){ return null }
-    static void throwPreLockException(){}
-    static void throwPostLockException(){}
-
     static ReservedVariableName byName(String name){
         return all().find{ reservedVar -> reservedVar.getName() == name }
     }
@@ -33,5 +29,9 @@ abstract class ReservedVariableName implements ExtensionPoint{
     static ExtensionList<ReservedVariableName> all() {
         return Jenkins.get().getExtensionList(ReservedVariableName)
     }
+
+    abstract String getName()
+    abstract void throwPreLockException() throws Exception
+    abstract void throwPostLockException() throws Exception
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/ReservedVariableName.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/ReservedVariableName.groovy
@@ -31,7 +31,15 @@ abstract class ReservedVariableName implements ExtensionPoint{
     }
 
     abstract String getName()
-    abstract void throwPreLockException() throws Exception
-    abstract void throwPostLockException() throws Exception
+
+    abstract String getExceptionMessage()
+
+    void throwPreLockException() throws Exception{
+        throw new Exception(getExceptionMessage())
+    }
+
+    void throwPostLockException() throws Exception{
+        throw new Exception(getExceptionMessage())
+    }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
@@ -29,16 +29,15 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 @SuppressWarnings(['EmptyMethodInAbstractClass', 'UnusedMethodParameter'])
 abstract class TemplatePrimitiveInjector implements ExtensionPoint{
 
-    // Optional. delegate injecting template primitives into the binding to the specific
-    // implementations of TemplatePrimitive
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){}
-
-    // Optional. do post processing of the config and binding.
-    static void doPostInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){}
-
-    // used to get all injectors
+    /**
+     * find all registered injectors
+     * @return all registered injectors
+     */
     static ExtensionList<TemplatePrimitiveInjector> all(){
         return Jenkins.get().getExtensionList(TemplatePrimitiveInjector)
     }
+
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){}
+    void doPostInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){}
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookInjector.groovy
@@ -30,8 +30,22 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
  */
 @Extension class HookInjector extends TemplatePrimitiveInjector {
 
-    @SuppressWarnings('UnusedMethodParameter')
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+    static Class getHooksClass(){
+        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
+        String self = this.getMetaClass().getTheClass().getName()
+        String classText = uberClassLoader.loadClass(self).getResource("Hooks.groovy").text
+        return TemplateScriptEngine.parseClass(classText)
+    }
+
+    static Class getAnnotatedMethodClass(){
+        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
+        String self = this.getMetaClass().getTheClass().getName()
+        String classText = uberClassLoader.loadClass(self).getResource("AnnotatedMethod.groovy").text
+        return TemplateScriptEngine.parseClass(classText)
+    }
+
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class hooksClass = getHooksClass()
         getAnnotatedMethodClass()
 
@@ -45,20 +59,6 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
         binding.setVariable("Init", Init)
         binding.setVariable("CleanUp", CleanUp)
         binding.setVariable("Notify", Notify)
-    }
-
-    static Class getHooksClass(){
-        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
-        String self = this.getMetaClass().getTheClass().getName()
-        String classText = uberClassLoader.loadClass(self).getResource("Hooks.groovy").text
-        return TemplateScriptEngine.parseClass(classText)
-    }
-
-    static Class getAnnotatedMethodClass(){
-        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
-        String self = this.getMetaClass().getTheClass().getName()
-        String classText = uberClassLoader.loadClass(self).getResource("AnnotatedMethod.groovy").text
-        return TemplateScriptEngine.parseClass(classText)
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
@@ -24,8 +24,16 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 @Extension class ApplicationEnvironmentInjector extends TemplatePrimitiveInjector {
 
-    @SuppressWarnings(['UnusedMethodParameter', 'NoDef'])
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+    static Class getPrimitiveClass(){
+        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
+        String self = this.getMetaClass().getTheClass().getName()
+        String classText = uberClassLoader.loadClass(self).getResource("ApplicationEnvironment.groovy").text
+        return TemplateScriptEngine.parseClass(classText)
+    }
+
+    @SuppressWarnings('NoDef')
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class appEnvClass = getPrimitiveClass()
         ArrayList createdEnvs = []
         config.getConfig().application_environments.each{ name, appEnvConfig ->
@@ -39,13 +47,6 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             env.setPrevious(previous)
             env.setNext(next)
         }
-    }
-
-    static Class getPrimitiveClass(){
-        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
-        String self = this.getMetaClass().getTheClass().getName()
-        String classText = uberClassLoader.loadClass(self).getResource("ApplicationEnvironment.groovy").text
-        return TemplateScriptEngine.parseClass(classText)
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
@@ -24,19 +24,19 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 @Extension class KeywordInjector extends TemplatePrimitiveInjector {
 
-    @SuppressWarnings('UnusedMethodParameter')
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
-        Class keywordClass = getPrimitiveClass()
-        config.getConfig().keywords.each{ key, value ->
-            binding.setVariable(key, keywordClass.newInstance(var_name: key, value: value))
-        }
-    }
-
     static Class getPrimitiveClass(){
         ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
         String self = this.getMetaClass().getTheClass().getName()
         String classText = uberClassLoader.loadClass(self).getResource("Keyword.groovy").text
         return TemplateScriptEngine.parseClass(classText)
+    }
+
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+        Class keywordClass = getPrimitiveClass()
+        config.getConfig().keywords.each{ key, value ->
+            binding.setVariable(key, keywordClass.newInstance(var_name: key, value: value))
+        }
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryLoader.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryLoader.groovy
@@ -30,7 +30,8 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob
 @Extension
 class LibraryLoader extends TemplatePrimitiveInjector {
 
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, TemplateBinding binding){
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         // 1. Inject steps from loaded libraries
         WorkflowJob job = flowOwner.run().getParent()
         List<GovernanceTier> tiers = GovernanceTier.getHierarchy(job)
@@ -86,7 +87,8 @@ class LibraryLoader extends TemplatePrimitiveInjector {
         }
     }
 
-    static void doPostInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+    @Override
+    void doPostInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         // 3. Inject a passthrough step for steps not defined (either as steps or other primitives)
         StepWrapperFactory stepFactory = new StepWrapperFactory(flowOwner)
         config.getConfig().template_methods.findAll{ step ->

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryLoader.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryLoader.groovy
@@ -21,7 +21,6 @@ import org.boozallen.plugins.jte.init.dsl.TemplateConfigException
 import org.boozallen.plugins.jte.init.governance.GovernanceTier
 import org.boozallen.plugins.jte.init.governance.libs.LibraryProvider
 import org.boozallen.plugins.jte.init.governance.libs.LibrarySource
-import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
@@ -24,8 +24,9 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
     static final String VARIABLE = "pipelineConfig"
 
-    @SuppressWarnings(['UnusedMethodParameter', 'NoDef'])
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+    @SuppressWarnings('NoDef')
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class keywordClass = KeywordInjector.getPrimitiveClass()
         def pipelineConfig = keywordClass.newInstance(
             var_name: VARIABLE,

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
@@ -24,21 +24,21 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 @Extension class StageInjector extends TemplatePrimitiveInjector {
 
-    @SuppressWarnings('UnusedMethodParameter')
-    static void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
+    static Class getPrimitiveClass(){
+        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
+        String self = this.getMetaClass().getTheClass().getName()
+        String classText = uberClassLoader.loadClass(self).getResource("Stage.groovy").text
+        return TemplateScriptEngine.parseClass(classText)
+    }
+
+    @Override
+    void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class stageClass = getPrimitiveClass()
         config.getConfig().stages.each{ name, steps ->
             ArrayList<String> stepsList = []
             steps.collect(stepsList){ step -> step.key }
             binding.setVariable(name, stageClass.newInstance(binding, name, stepsList))
         }
-    }
-
-    static Class getPrimitiveClass(){
-        ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
-        String self = this.getMetaClass().getTheClass().getName()
-        String classText = uberClassLoader.loadClass(self).getResource("Stage.groovy").text
-        return TemplateScriptEngine.parseClass(classText)
     }
 
     static class StageContext implements Serializable {

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
@@ -41,4 +41,10 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
         return TemplateScriptEngine.parseClass(classText)
     }
 
+    static class StageContext implements Serializable {
+        private static final long serialVersionUID = 1L
+        String name
+        Map args = [:]
+    }
+
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
@@ -18,14 +18,21 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.AbortException
 import hudson.FilePath
 import jenkins.model.Jenkins
+import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.boozallen.plugins.jte.util.TemplateScriptEngine
 import org.boozallen.plugins.jte.init.primitives.ReservedVariableName
 import hudson.Extension
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.customizers.ImportCustomizer
+import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.boozallen.plugins.jte.job.TemplateFlowDefinition
 import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+import javax.annotation.CheckForNull
 
 /**
  * Produces StepWrappers from a variety of input sources
@@ -80,43 +87,83 @@ class StepWrapperFactory{
      * @param source the source code text
      * @param binding the TemplateBinding resolvable during invocation
      * @param config the library configuration
+     * @param optional {@link StageContext}
+     * @param optional {@link HookContext}
      * @return an executable and wired executable script
      */
-    Script prepareScript(String library, String name, String source, Binding binding, Map config){
-        CpsScript script
+    StepWrapperScript prepareScript(
+            String library,
+            String name,
+            String source,
+            Binding binding,
+            LinkedHashMap config,
+            StageContext stageContext = null,
+            HookContext hookContext = null
+    ){
+        StepWrapperScript script
+        /*
+         * first: parse the step the same way Jenkins parses a Jenkinsfile
+         *        this is easiest way to appropriately attach the flowOwner
+         *        of the template to the Step. attaching the flowOwner is
+         *        necessary for certain Jenkins Pipeline steps to work appropriately.
+         */
         try{
-            script = new CpsFlowExecution(
+            CpsFlowExecution exec = new CpsFlowExecution(
                 source,
                 false,
                 flowOwner,
                 TemplateFlowDefinition.determineFlowDurabilityHint(flowOwner)
-            ).parseScript()
+            )
+            // tell StepWrapperShellDecorator this is a step
+            exec.metaClass[StepWrapperShellDecorator.FLAG] = true
+            script = exec.parseScript() as StepWrapperScript
         } catch(any){
             TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
             logger.printError("Failed to parse step text. Library: ${library}. Step: ${name}.")
             throw any
         }
-
-        script.metaClass."get${CONFIG_VAR.capitalize()}" << { return config }
-        script.metaClass.getStageContext = { [ name: null, args: [:] ] }
-
-        script.metaClass.resource = { String resource ->
-            if(resource.startsWith("/")){
-                throw new AbortException("JTE: The ${name} step from the ${library} library requested a resource '${resource}' that is not a relative path.  Must not begin with /.")
-            }
-            FilePath rootDir = new FilePath(flowOwner.getRootDir())
-            FilePath resourceFile = rootDir.child("jte/${library}/resources/${resource}")
-            if(!resourceFile.exists()){
-                throw new AbortException("JTE: The ${name} step from the ${library} library requested a resource '${resource}' that does not exist")
-            } else if(resourceFile.isDirectory()){
-                throw new AbortException("JTE: The ${name} step from the ${library} library requested a resource '${resource}' that is a directory. Must be a file.")
-            }
-            return resourceFile.readToString()
-        }
-
+        /*
+         * second: attach the common TemplateBinding
+         */
         script.setBinding(binding)
-
+        /*
+         * finally: set whatever runtime specific contexts are required for this step, such as:
+         *       1. the library configuration
+         *       2. the base directory from which to fetch library resources
+         *       3. an optional StageContext
+         *       4. an optional HookContext
+         */
+        script.setConfig(config)
+        FilePath baseDir = new FilePath(flowOwner.getRootDir()).child("jte/${library}/resources")
+        script.setResourcesBaseDir(baseDir)
+        stageContext && script.setStageContext(stageContext)
+        hookContext  && script.setHookContext(hookContext)
         return script
+    }
+
+    /**
+     * Registers a compiler customization for parsing StepWrappers
+     */
+    @Extension static class StepWrapperShellDecorator extends GroovyShellDecorator {
+        /**
+         * The name of a property that will be added to CpsFlowExecution's used to
+         * parse a StepWrapper script.
+         * <p>
+         * Simplifies determining if a CpsFlowExecution's script compliation should
+         * be modified by this decorator.
+         */
+        private static final String FLAG = "JTE_STEP"
+        @Override
+        void configureCompiler(@CheckForNull final CpsFlowExecution execution, CompilerConfiguration cc) {
+            if(execution.hasProperty(FLAG)){
+                // auto import lifecycle hook annotations within steps
+                ImportCustomizer ic = new ImportCustomizer()
+                ic.addStarImports("org.boozallen.plugins.jte.init.primitives.hooks")
+                cc.addCompilationCustomizers(ic)
+                // set script base class to our own
+                cc.setScriptBaseClass(StepWrapperScript.name)
+            }
+        }
     }
 
     /**
@@ -137,7 +184,7 @@ class StepWrapperFactory{
             config: config,
             sourceText: sourceText,
             // parse to fail fast for step compilation issues
-            impl: prepareScript(library, name, sourceText, binding, config)
+            script: prepareScript(library, name, sourceText, binding, config)
         )
     }
 
@@ -161,7 +208,7 @@ class StepWrapperFactory{
             config: config,
             sourceFile: filePath.absolutize().getRemote(),
             // parse to fail fast for step compilation issues
-            impl: prepareScript(library, name, sourceText, binding, config)
+            script: prepareScript(library, name, sourceText, binding, config)
         )
     }
 
@@ -176,10 +223,10 @@ class StepWrapperFactory{
     def createDefaultStep(Binding binding, String name, Map stepConfig){
         ClassLoader uberClassLoader = Jenkins.get().pluginManager.uberClassLoader
         String self = this.getMetaClass().getTheClass().getName()
-        String defaultImpl = uberClassLoader.loadClass(self).getResource("defaultStepImplementation.groovy").text
+        String defaultStep = uberClassLoader.loadClass(self).getResource("defaultStepImplementation.groovy").text
         // will be nice to eventually use the ?= operator when groovy version gets upgraded
         stepConfig.name = stepConfig.name ?: name
-        return createFromString(defaultImpl, binding, name, "Default Step Implementation", stepConfig)
+        return createFromString(defaultStep, binding, name, "Default Step Implementation", stepConfig)
     }
 
     /**
@@ -189,8 +236,8 @@ class StepWrapperFactory{
      * @return a no-op StepWrapper
      */
     def createNullStep(String stepName, Binding binding){
-        String nullImpl = "def call(){ println \"Step ${stepName} is not implemented.\" }"
-        return createFromString(nullImpl, binding, stepName, null, [:])
+        String nullStep = "def call(){ println \"Step ${stepName} is not implemented.\" }"
+        return createFromString(nullStep, binding, stepName, null, [:])
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
@@ -15,7 +15,6 @@
 */
 package org.boozallen.plugins.jte.init.primitives.injectors
 
-import hudson.AbortException
 import hudson.FilePath
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
@@ -30,7 +29,6 @@ import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.boozallen.plugins.jte.job.TemplateFlowDefinition
-import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 import javax.annotation.CheckForNull
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
@@ -21,7 +21,6 @@ import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.boozallen.plugins.jte.util.TemplateScriptEngine
-import org.boozallen.plugins.jte.init.primitives.ReservedVariableName
 import hudson.Extension
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ImportCustomizer
@@ -45,19 +44,6 @@ class StepWrapperFactory{
      * configuration to the step
      */
     static final String CONFIG_VAR = "config"
-
-    /**
-     * reserves ${CONFIG_VAR} as a protected variable name in the TemplateBinding
-     */
-    @Extension static class ReservedVariableNameImpl extends ReservedVariableName{
-        static String getName(){ return CONFIG_VAR }
-        static void throwPreLockException(){
-            throw new Exception("Variable name ${CONFIG_VAR} is reserved for steps to access their library configuration")
-        }
-        static void throwPostLockException(){
-            throw new Exception("Variable name ${CONFIG_VAR} is reserved for steps to access their library configuration")
-        }
-    }
 
     private final FlowExecutionOwner flowOwner
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
@@ -75,6 +75,7 @@ class StepWrapperFactory{
      * @param optional {@link HookContext}
      * @return an executable and wired executable script
      */
+    @SuppressWarnings("ParameterCount")
     StepWrapperScript prepareScript(
             String library,
             String name,

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -1,0 +1,88 @@
+package org.boozallen.plugins.jte.init.primitives.injectors;
+
+import hudson.AbortException;
+import hudson.FilePath;
+import org.boozallen.plugins.jte.init.primitives.hooks.HookContext;
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+/**
+ * The base script used during step execution
+ */
+public abstract class StepWrapperScript extends CpsScript {
+
+    /**
+     * The library configuration
+     */
+    LinkedHashMap config = new LinkedHashMap();
+
+    /**
+     * The hook context information
+     */
+    HookContext hookContext = new HookContext();
+
+    /**
+     * The stage context
+     */
+    StageContext stageContext = new StageContext();
+
+    /**
+     * The FilePath within the build directory from which
+     * resources can be fetched
+     */
+    private FilePath resourcesBaseDir;
+
+    public StepWrapperScript() throws IOException { super(); }
+
+    public void setConfig(LinkedHashMap config){
+        this.config = config;
+    }
+
+    public LinkedHashMap getConfig(){
+        return config;
+    }
+
+    public void setHookContext(HookContext hookContext){
+        this.hookContext = hookContext;
+    }
+
+    public HookContext getHookContext(){
+        return hookContext;
+    }
+
+    public void setStageContext(StageContext stageContext){
+        this.stageContext = stageContext;
+    }
+
+    public StageContext getStageContext() {
+        return stageContext;
+    }
+
+    public void setResourcesBaseDir(FilePath resourcesBaseDir) {
+        this.resourcesBaseDir = resourcesBaseDir;
+    }
+
+    /**
+     * Used within steps to access library resources
+     *
+     * @param path relative path within the resources directory to fetch
+     * @return the resource file contents
+     */
+    public String resource(String path) throws IOException, InterruptedException {
+        if (path.startsWith("/")){
+            throw new AbortException("JTE: library step requested a resource that is not a relative path.");
+        }
+        FilePath resourceFile = resourcesBaseDir.child(path);
+        if(!resourceFile.exists()){
+            String oopsMsg = String.format("JTE: library step requested a resource '%s' that does not exist", path);
+            throw new AbortException(oopsMsg);
+        } else if(resourceFile.isDirectory()){
+            String oopsMsg = String.format("JTE: library step requested a resource '%s' that is not a file.", path);
+            throw new AbortException(oopsMsg);
+        }
+        return resourceFile.readToString();
+    }
+}

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -1,3 +1,18 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
 package org.boozallen.plugins.jte.init.primitives.injectors;
 
 import hudson.AbortException;

--- a/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -64,11 +64,9 @@ public abstract class StepWrapperScript extends CpsScript {
      */
     @Extension public static class ConfigReservedVariable extends ReservedVariableName {
         public String getName(){ return "config"; }
-        private String getExceptionMessage(){
+        @Override public String getExceptionMessage(){
             return String.format("Variable name %s is reserved for steps to access their library configuration", getName());
         }
-        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
-        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setHookContext(HookContext hookContext){
@@ -81,11 +79,9 @@ public abstract class StepWrapperScript extends CpsScript {
      */
     @Extension public static class HookContextReservedVariable extends ReservedVariableName {
         public String getName(){ return "hookContext"; }
-        private String getExceptionMessage(){
+        @Override public String getExceptionMessage(){
             return String.format("Variable name %s is reserved for steps to access their hook context", getName());
         }
-        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
-        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setStageContext(StageContext stageContext){
@@ -98,11 +94,9 @@ public abstract class StepWrapperScript extends CpsScript {
      */
     @Extension public static class StageContextReservedVariable extends ReservedVariableName {
         public String getName(){ return "stageContext"; }
-        private String getExceptionMessage(){
+        @Override public String getExceptionMessage(){
             return String.format("Variable name %s is reserved for steps to access their stage context", getName());
         }
-        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
-        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setResourcesBaseDir(FilePath resourcesBaseDir) {
@@ -135,10 +129,8 @@ public abstract class StepWrapperScript extends CpsScript {
      */
     @Extension public static class ResourceReservedVariable extends ReservedVariableName {
         public String getName(){ return "resource"; }
-        private String getExceptionMessage(){
+        @Override public String getExceptionMessage(){
             return String.format("Variable name %s is reserved for steps to access library resources", getName());
         }
-        public void throwPreLockException() throws Exception{  throw new Exception(getExceptionMessage()); }
-        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 }

--- a/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -63,16 +63,12 @@ public abstract class StepWrapperScript extends CpsScript {
      * reserves the config var from being overridden in the binding
      */
     @Extension public static class ConfigReservedVariable extends ReservedVariableName {
-        private static final String config = "config";
-        public String getName(){ return config; }
-        public void throwPreLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their library configuration", config);
-            throw new Exception(oopsMsg);
+        public String getName(){ return "config"; }
+        private String getExceptionMessage(){
+            return String.format("Variable name %s is reserved for steps to access their library configuration", getName());
         }
-        public void throwPostLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their library configuration", config);
-            throw new Exception(oopsMsg);
-        }
+        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
+        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setHookContext(HookContext hookContext){
@@ -84,16 +80,12 @@ public abstract class StepWrapperScript extends CpsScript {
      * reserves the config var from being overridden in the binding
      */
     @Extension public static class HookContextReservedVariable extends ReservedVariableName {
-        private static final String hookContext = "hookContext";
-        public String getName(){ return hookContext; }
-        public void throwPreLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their hook context", hookContext);
-            throw new Exception(oopsMsg);
+        public String getName(){ return "hookContext"; }
+        private String getExceptionMessage(){
+            return String.format("Variable name %s is reserved for steps to access their hook context", getName());
         }
-        public void throwPostLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their hook context", hookContext);
-            throw new Exception(oopsMsg);
-        }
+        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
+        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setStageContext(StageContext stageContext){
@@ -105,16 +97,12 @@ public abstract class StepWrapperScript extends CpsScript {
      * reserves the config var from being overridden in the binding
      */
     @Extension public static class StageContextReservedVariable extends ReservedVariableName {
-        private static final String stageContext = "stageContext";
-        public String getName(){ return stageContext; }
-        public void throwPreLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their stage context", stageContext);
-            throw new Exception(oopsMsg);
+        public String getName(){ return "stageContext"; }
+        private String getExceptionMessage(){
+            return String.format("Variable name %s is reserved for steps to access their stage context", getName());
         }
-        public void throwPostLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access their stage context", stageContext);
-            throw new Exception(oopsMsg);
-        }
+        public void throwPreLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
+        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 
     public void setResourcesBaseDir(FilePath resourcesBaseDir) {
@@ -146,15 +134,11 @@ public abstract class StepWrapperScript extends CpsScript {
      * reserves the config var from being overridden in the binding
      */
     @Extension public static class ResourceReservedVariable extends ReservedVariableName {
-        private static final String resource = "resource";
-        public String getName(){ return resource; }
-        public void throwPreLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access library resources", resource);
-            throw new Exception(oopsMsg);
+        public String getName(){ return "resource"; }
+        private String getExceptionMessage(){
+            return String.format("Variable name %s is reserved for steps to access library resources", getName());
         }
-        public void throwPostLockException() throws Exception{
-            String oopsMsg = String.format("Variable name %s is reserved for steps to access library resources", resource);
-            throw new Exception(oopsMsg);
-        }
+        public void throwPreLockException() throws Exception{  throw new Exception(getExceptionMessage()); }
+        public void throwPostLockException() throws Exception{ throw new Exception(getExceptionMessage()); }
     }
 }

--- a/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -51,31 +51,15 @@ public abstract class StepWrapperScript extends CpsScript {
     private FilePath resourcesBaseDir;
 
     public StepWrapperScript() throws IOException { super(); }
-
     public void setConfig(LinkedHashMap config){
         this.config = config;
     }
-
-    public LinkedHashMap getConfig(){
-        return config;
-    }
-
     public void setHookContext(HookContext hookContext){
         this.hookContext = hookContext;
     }
-
-    public HookContext getHookContext(){
-        return hookContext;
-    }
-
     public void setStageContext(StageContext stageContext){
         this.stageContext = stageContext;
     }
-
-    public StageContext getStageContext() {
-        return stageContext;
-    }
-
     public void setResourcesBaseDir(FilePath resourcesBaseDir) {
         this.resourcesBaseDir = resourcesBaseDir;
     }

--- a/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -51,15 +51,22 @@ public abstract class StepWrapperScript extends CpsScript {
     private FilePath resourcesBaseDir;
 
     public StepWrapperScript() throws IOException { super(); }
+
     public void setConfig(LinkedHashMap config){
         this.config = config;
     }
+    public LinkedHashMap getConfig(){ return config; }
+
     public void setHookContext(HookContext hookContext){
         this.hookContext = hookContext;
     }
+    public HookContext getHookContext(){ return hookContext; }
+
     public void setStageContext(StageContext stageContext){
         this.stageContext = stageContext;
     }
+    public StageContext getStageContext(){ return stageContext; }
+
     public void setResourcesBaseDir(FilePath resourcesBaseDir) {
         this.resourcesBaseDir = resourcesBaseDir;
     }

--- a/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
+++ b/src/main/java/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScript.java
@@ -16,7 +16,9 @@
 package org.boozallen.plugins.jte.init.primitives.injectors;
 
 import hudson.AbortException;
+import hudson.Extension;
 import hudson.FilePath;
+import org.boozallen.plugins.jte.init.primitives.ReservedVariableName;
 import org.boozallen.plugins.jte.init.primitives.hooks.HookContext;
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
@@ -57,15 +59,63 @@ public abstract class StepWrapperScript extends CpsScript {
     }
     public LinkedHashMap getConfig(){ return config; }
 
+    /**
+     * reserves the config var from being overridden in the binding
+     */
+    @Extension public static class ConfigReservedVariable extends ReservedVariableName {
+        private static final String config = "config";
+        public String getName(){ return config; }
+        public void throwPreLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their library configuration", config);
+            throw new Exception(oopsMsg);
+        }
+        public void throwPostLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their library configuration", config);
+            throw new Exception(oopsMsg);
+        }
+    }
+
     public void setHookContext(HookContext hookContext){
         this.hookContext = hookContext;
     }
     public HookContext getHookContext(){ return hookContext; }
 
+    /**
+     * reserves the config var from being overridden in the binding
+     */
+    @Extension public static class HookContextReservedVariable extends ReservedVariableName {
+        private static final String hookContext = "hookContext";
+        public String getName(){ return hookContext; }
+        public void throwPreLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their hook context", hookContext);
+            throw new Exception(oopsMsg);
+        }
+        public void throwPostLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their hook context", hookContext);
+            throw new Exception(oopsMsg);
+        }
+    }
+
     public void setStageContext(StageContext stageContext){
         this.stageContext = stageContext;
     }
     public StageContext getStageContext(){ return stageContext; }
+
+    /**
+     * reserves the config var from being overridden in the binding
+     */
+    @Extension public static class StageContextReservedVariable extends ReservedVariableName {
+        private static final String stageContext = "stageContext";
+        public String getName(){ return stageContext; }
+        public void throwPreLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their stage context", stageContext);
+            throw new Exception(oopsMsg);
+        }
+        public void throwPostLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access their stage context", stageContext);
+            throw new Exception(oopsMsg);
+        }
+    }
 
     public void setResourcesBaseDir(FilePath resourcesBaseDir) {
         this.resourcesBaseDir = resourcesBaseDir;
@@ -90,5 +140,21 @@ public abstract class StepWrapperScript extends CpsScript {
             throw new AbortException(oopsMsg);
         }
         return resourceFile.readToString();
+    }
+
+    /**
+     * reserves the config var from being overridden in the binding
+     */
+    @Extension public static class ResourceReservedVariable extends ReservedVariableName {
+        private static final String resource = "resource";
+        public String getName(){ return resource; }
+        public void throwPreLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access library resources", resource);
+            throw new Exception(oopsMsg);
+        }
+        public void throwPostLockException() throws Exception{
+            String oopsMsg = String.format("Variable name %s is reserved for steps to access library resources", resource);
+            throw new Exception(oopsMsg);
+        }
     }
 }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
@@ -37,10 +37,11 @@ class AnnotatedMethod implements Serializable{
 
     void invoke(HookContext context){
         try{
-            def script = stepWrapper.getScript()
+            def step = stepWrapper.clone()
+            def script = step.getScript()
             script.setHookContext(context)
-            String lib = stepWrapper.library
-            String step = stepWrapper.name 
+            String lib = step.library
+            String step = step.name
             TemplateLogger.createDuringRun().print "[@${annotationName} - ${lib}/${step}.${methodName}]"
             InvokerHelper.getMetaClass(script).invokeMethod(script, methodName, null)
         } catch (Exception x) {

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
@@ -25,15 +25,15 @@ import java.lang.annotation.Annotation
 class AnnotatedMethod implements Serializable{
     Annotation annotation
     String annotationName
-    def stepWrapper 
+    def stepWrapper
     String methodName
 
     AnnotatedMethod(Annotation annotation, String annotationName, String methodName, def stepWrapper){
         this.annotation = annotation
         this.annotationName = annotationName
         this.methodName = methodName
-        this.stepWrapper = stepWrapper 
-    } 
+        this.stepWrapper = stepWrapper
+    }
 
     void invoke(HookContext context){
         try{
@@ -41,8 +41,8 @@ class AnnotatedMethod implements Serializable{
             def script = step.getScript()
             script.setHookContext(context)
             String lib = step.library
-            String step = step.name
-            TemplateLogger.createDuringRun().print "[@${annotationName} - ${lib}/${step}.${methodName}]"
+            String stepName = step.name
+            TemplateLogger.createDuringRun().print "[@${annotationName} - ${lib}/${stepName}.${methodName}]"
             InvokerHelper.getMetaClass(script).invokeMethod(script, methodName, null)
         } catch (Exception x) {
             throw new InvokerInvocationException(x)

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
@@ -48,4 +48,4 @@ class AnnotatedMethod implements Serializable{
             throw new InvokerInvocationException(x)
         }
     }
-}   
+}

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/hooks/AnnotatedMethod.groovy
@@ -37,10 +37,12 @@ class AnnotatedMethod implements Serializable{
 
     void invoke(HookContext context){
         try{
+            def script = stepWrapper.getScript()
+            script.setHookContext(context)
             String lib = stepWrapper.library
             String step = stepWrapper.name 
             TemplateLogger.createDuringRun().print "[@${annotationName} - ${lib}/${step}.${methodName}]"
-            InvokerHelper.getMetaClass(stepWrapper.impl).invokeMethod(stepWrapper.impl, methodName, context)
+            InvokerHelper.getMetaClass(script).invokeMethod(script, methodName, null)
         } catch (Exception x) {
             throw new InvokerInvocationException(x)
         }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -16,20 +16,17 @@
 
 package org.boozallen.plugins.jte.init.primitives.injectors
 
-import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.TemplateLogger
-import org.codehaus.groovy.runtime.InvokerHelper
 
-/*
-    represents a group of library steps to be called. 
-*/
+/**
+ *  represents a group of library steps to be called.
+ */
 class Stage extends TemplatePrimitive implements Serializable{
 
-    static EMPTY_CONTEXT = [ name: null, args: [:] ]
-
-    Binding binding 
+    Binding binding
     String name
     ArrayList<String> steps
 
@@ -38,33 +35,17 @@ class Stage extends TemplatePrimitive implements Serializable{
     Stage(Binding binding, String name, ArrayList<String> steps){
         this.binding = binding
         this.name = name
-        this.steps = steps 
+        this.steps = steps
     }
 
-    void call(stageConfig){
+    void call(args) {
         TemplateLogger.createDuringRun().print "[Stage - ${name}]"
-
-        def stageContext = [
-            name: name,
-            args: stageConfig
-        ]
-
-        for(def i = 0; i < steps.size(); i++){
-            String step = steps.get(i)
-            setStageContext(step, stageContext)
-            binding.getStep(step).call()
-            setStageContext(step, EMPTY_CONTEXT)
+        StageContext stageContext = new StageContext(name: name, args: args)
+        steps.each{ step ->
+            def clone = binding.getStep(step).clone()
+            clone.setStageContext(stageContext)
+            clone()
         }
-    }
-
-    @NonCPS
-    private void setStageContext(String step, stageContext) {
-        if(!binding.hasStep(step)) {
-            return
-        }
-        def impl = binding.getStep(step)?.impl
-        def metaClass = InvokerHelper.getMetaClass(impl)
-        metaClass.getStageContext = {-> stageContext}
     }
 
     void throwPreLockException(){

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -44,7 +44,7 @@ class Stage extends TemplatePrimitive implements Serializable{
         steps.each{ step ->
             def clone = binding.getStep(step).clone()
             clone.setStageContext(stageContext)
-            clone()
+            clone.call()
         }
     }
 

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -23,6 +23,7 @@ import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.hooks.*
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.codehaus.groovy.runtime.InvokerInvocationException
@@ -30,15 +31,11 @@ import org.jenkinsci.plugins.workflow.cps.CpsThread
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
-/*
-    represents a library step. 
+/**
+ * A library step
+ */
+class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
 
-    this class serves as a wrapper class for the library step Script. 
-    It's necessary for two reasons: 
-    1. To give steps binding protection via TemplatePrimitive
-    2. To provide a means to do LifeCycle Hooks before/after step execution
-*/
-class StepWrapper extends TemplatePrimitive implements Serializable{
     /**
      * The name of the step
      */
@@ -69,10 +66,37 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
     /**
      * A caching of the parsed source text used during invocation
      */
-    private transient Object impl
+    private transient StepWrapperScript script
+
+    /**
+     * optional StageContext. assumes nondefault value of this step is
+     * running as part of a Stage
+     */
+    private StageContext stageContext
+
+    /**
+     * optional HookContext. assumes nondefault value if this step was
+     * invoked because of a lifecycle hook
+     */
+    private HookContext hookContext
 
     @NonCPS String getName(){ return name }
     @NonCPS String getLibrary(){ return library }
+
+    /**
+     * clones this StepWrapper
+     *
+     * @return An equivalent StepWrapper instance
+     */
+    StepWrapper clone(){
+        return new StepWrapper(
+            name: this.name,
+            library: this.library,
+            sourceText: this.sourceText,
+            sourceFile: this.sourceFile,
+            config: this.config
+        )
+    }
 
     /*
      * memoized getter.
@@ -80,17 +104,30 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
      *  1. prior to first invocation
      *  2. after a pipeline is resumed following an ungraceful shut down
      */
-    @NonCPS Object getImpl(){
-        if(!impl){
-            impl = parseSource()
+    @NonCPS StepWrapperScript getScript(){
+        if(!script){
+            script = parseSource()
         }
-        return impl
+        return script
     }
-    /*
 
-    */
+    void setStageContext(StageContext stageContext){
+        this.stageContext = stageContext
+        getScript().setStageContext(stageContext)
+    }
+
+    void setHookContext(HookContext hookContext){
+        this.hookContext = hookContext
+        getScript().setHookContext(hookContext)
+    }
+
+    /**
+     * recompiles the StepWrapperScript if missing. This typically only happens if
+     * Jenkins has ungracefully restarted and the pipeline is resuming
+     * @return
+     */
     @NonCPS
-    private Object parseSource(){
+    private StepWrapperScript parseSource(){
         CpsThread thread = CpsThread.current()
         if(!thread){
             throw new IllegalStateException("CpsThread not present.")
@@ -109,59 +146,56 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
             FilePath f = new FilePath(new File(sourceFile))
             if(f.exists()){
                 source = f.readToString()
-            }else{
+            } else{
                 throw new IllegalStateException("Unable to find source file '${sourceFile}' for StepWrapper[library: ${library}, name: ${name}]")
             }
-        }else if (sourceText){
+        } else if (sourceText){
             source = sourceText
-        }else{
+        } else{
             throw new IllegalStateException("Unable to determine StepWrapper[library: ${library}, name: ${name}] source.")
         }
 
         StepWrapperFactory factory = new StepWrapperFactory(flowOwner)
-        return factory.prepareScript(library, name, source, binding, config)
+        return factory.prepareScript(library, name, source, binding, config, stageContext, hookContext)
     }
     /*
-        need a call method defined on method missing so that 
-        CpsScript recognizes the StepWrapper as something it 
-        should execute in the binding. 
+        need a call method defined on method missing so that
+        CpsScript recognizes the StepWrapper as something it
+        should execute in the binding.
     */
     def call(Object... args) {
         return invoke("call", args)
     }
 
     /*
-        all other method calls go through CpsScript.getProperty to 
-        first retrieve the StepWrapper and then attempt to invoke a 
-        method on it. 
+        all other method calls go through CpsScript.getProperty to
+        first retrieve the StepWrapper and then attempt to invoke a
+        method on it.
     */
     def methodMissing(String methodName, args){
-        return invoke(methodName, args)     
+        return invoke(methodName, args)
     }
-    
+
     /*
         pass method invocations on the wrapper to the underlying
-        step implementation script. 
+        step implementation script.
     */
     def invoke(String methodName, Object... args){
-        if(InvokerHelper.getMetaClass(getImpl()).respondsTo(getImpl(), methodName, args)){
+        if(InvokerHelper.getMetaClass(getScript()).respondsTo(getScript(), methodName, args)){
             def result
-            HookContext context = new HookContext(
-                step: name, 
-                library: library
-            )
+            HookContext context = new HookContext(step: name, library: library)
             try{
                 Hooks.invoke(BeforeStep, context)
                 TemplateLogger.createDuringRun().print "[Step - ${library}/${name}.${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})]"
-                result = InvokerHelper.getMetaClass(getImpl()).invokeMethod(getImpl(), methodName, args)
+                result = InvokerHelper.getMetaClass(getScript()).invokeMethod(getScript(), methodName, args)
             } catch (Exception x) {
                 throw new InvokerInvocationException(x)
             } finally{
                 Hooks.invoke(AfterStep, context)
                 Hooks.invoke(Notify, context)
             }
-            return result 
-        }else{
+            return result
+        } else{
             throw new TemplateException("Step ${name} from the library ${library} does not have the method ${methodName}(${args.collect{ it.getClass().simpleName }.join(", ")})")
         }
     }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -88,14 +88,14 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
      *
      * @return An equivalent StepWrapper instance
      */
-    StepWrapper clone(){
-        return new StepWrapper(
-            name: this.name,
-            library: this.library,
-            sourceText: this.sourceText,
-            sourceFile: this.sourceFile,
-            config: this.config
-        )
+    Object clone(){
+        Object that = super.clone()
+        that.name = this.name
+        that.library = this.library
+        that.sourceText = this.sourceText
+        that.sourceFile = this.sourceFile
+        that.config = this.config
+        return that
     }
 
     /*

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookSpec.groovy
@@ -114,9 +114,9 @@ class HookSpec extends Specification{
         def run
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep("hooksLibrary", "theHooks", """
-        @BeforeStep({ context.step.equals("foo") })
-        void blah(context){
-            println "running before \${context.step}"
+        @BeforeStep({ hookContext.step.equals("foo") })
+        void blah(){
+            println "running before \${hookContext.step}"
         }
         """)
         libProvider.addStep("someLibrary", "foo", """
@@ -156,9 +156,9 @@ class HookSpec extends Specification{
         def run
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep("hooksLibrary", "theHooks", """
-        @BeforeStep({ context.step in config.beforeSteps })
-        void blah(context){
-            println "running before \${context.step}"
+        @BeforeStep({ hookContext.step in config.beforeSteps })
+        void blah(){
+            println "running before \${hookContext.step}"
         }
         """)
         libProvider.addStep("someLibrary", "foo", """
@@ -201,8 +201,8 @@ class HookSpec extends Specification{
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep("hooksLibrary", "theHooks", """
         @BeforeStep({ bar() })
-        void blah(context){
-            println "running before \${context.step}"
+        void blah(){
+            println "running before \${hookContext.step}"
         }
         """)
         libProvider.addStep("someLibrary", "foo", """
@@ -242,8 +242,8 @@ class HookSpec extends Specification{
         def run
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep("hooksLibrary", "theHooks", """
-        ${annotation} void foo(context){ println "step: foo" }
-        ${annotation} void bar(context){ println "step: bar" }
+        ${annotation} void foo(){ println "step: foo" }
+        ${annotation} void bar(){ println "step: bar" }
         """)
         libProvider.addStep("someLibrary", "theActualStep", "void call(){ println 'the actual step' }")
         libProvider.addGlobally()
@@ -271,12 +271,12 @@ class HookSpec extends Specification{
     }
 
     @Unroll
-    def "#annotation adherest to conditional execution when closure param is { #shouldRun }"(){
+    def "#annotation adheres to conditional execution when closure param is { #shouldRun }"(){
         given:
         def run
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep("hooksLibrary", "theHooks", """
-        ${annotation}({ ${shouldRun} }) void foo(context){ println "step: foo" }
+        ${annotation}({ ${shouldRun} }) void foo(){ println "step: foo" }
         """)
         libProvider.addStep("someLibrary", "theActualStep", "void call(){ println 'the actual step' }")
         libProvider.addGlobally()

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperSpec.groovy
@@ -464,7 +464,7 @@ class StepWrapperSpec extends Specification{
         then:
         jenkins.assertBuildStatus(Result.FAILURE, run)
         jenkins.assertLogContains("hello, world", run)
-        jenkins.assertLogContains("JTE: The fetchCrossLibrary step from the resourcesB library requested a resource 'nested/somethingElse.txt' that does not exist", run)
+        jenkins.assertLogContains("JTE: library step requested a resource 'nested/somethingElse.txt' that does not exist", run)
     }
 
     def "step fetching non-existent resource throws exception"(){
@@ -484,7 +484,7 @@ class StepWrapperSpec extends Specification{
 
         then:
         jenkins.assertBuildStatus(Result.FAILURE, run)
-        jenkins.assertLogContains("JTE: The doesNotExist step from the resourcesB library requested a resource 'nope.txt' that does not exist", run)
+        jenkins.assertLogContains("JTE: library step requested a resource 'nope.txt' that does not exist", run)
     }
 
     def "step fetching resource with absolute path throws exception"(){
@@ -504,7 +504,7 @@ class StepWrapperSpec extends Specification{
 
         then:
         jenkins.assertBuildStatus(Result.FAILURE, run)
-        jenkins.assertLogContains("JTE: The absolutePath step from the resourcesB library requested a resource '/nope.txt' that is not a relative path.  Must not begin with /.", run)
+        jenkins.assertLogContains("JTE: library step requested a resource that is not a relative path.", run)
     }
 
 }

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperSpec.groovy
@@ -17,12 +17,15 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 
 import hudson.model.Result
 import org.boozallen.plugins.jte.init.governance.libs.TestLibraryProvider
+import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.util.TestUtil
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.WithoutJenkins
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class StepWrapperSpec extends Specification{
 
@@ -505,6 +508,19 @@ class StepWrapperSpec extends Specification{
         then:
         jenkins.assertBuildStatus(Result.FAILURE, run)
         jenkins.assertLogContains("JTE: library step requested a resource that is not a relative path.", run)
+    }
+
+    @WithoutJenkins
+    @Unroll
+    def "overriding autowired variable #var in binding throws exception"(){
+        given:
+        TemplateBinding binding = new TemplateBinding()
+        when:
+        binding.setVariable(var, "_")
+        then:
+        thrown(Exception)
+        where:
+        var << [ "config", "stageContext", "hookContext", "resource" ]
     }
 
 }


### PR DESCRIPTION
# PR Details

* changes the approach to autowiring variables and functionality to library steps.
* a `StageContext` class has been created to formalize that data structure as opposed to passing a `Map` around
* autowires the `hookContext` to steps and removes the step method parameter

## Description

Previously, JTE handles autowiring of values and some functionality via runtime metaprogramming. 

This PR introduces a new `GroovyShellDecorator` that customizes the compilation for library steps to set a custom runtime base script. 

## How Has This Been Tested

- unit tests pass

## Validation

Beyond the auto-wiring of `hookContext` variable, the changes should be transparent to end users. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
