### PR TITLE
first draft of primitive namespaces

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
@@ -23,6 +23,7 @@ import org.boozallen.plugins.jte.init.governance.GovernanceTier
 import org.boozallen.plugins.jte.init.governance.config.ScmPipelineConfigurationProvider
 import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
+import org.boozallen.plugins.jte.init.primitives.JteNamespace
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
 import org.boozallen.plugins.jte.util.TemplateLogger
@@ -125,6 +126,12 @@ class PipelineDecorator extends InvisibleAction {
         injectors.each{ injector ->
             injector.doPostInject(flowOwner, config, templateBinding)
         }
+
+        JteNamespace jte = new JteNamespace()
+        templateBinding.getPrimitives().each{ primitive ->
+            primitive.getInjector().populateNamespace(jte, primitive)
+        }
+        templateBinding.setVariable("jte", jte)
 
         templateBinding.lock()
         return templateBinding

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/JteNamespace.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/JteNamespace.groovy
@@ -1,0 +1,53 @@
+package org.boozallen.plugins.jte.init.primitives
+
+import hudson.AbortException
+
+import javax.annotation.Nonnull
+
+class JteNamespace extends TemplatePrimitive implements Serializable{
+
+    private static final long serialVersionUID = 1L
+
+    List<Namespace> namespaces = []
+
+    @Override String getName(){ return null }
+    @Override Class getInjector(){ return null }
+
+    @Override
+    void throwPreLockException() {
+        throw new Exception("prelock")
+    }
+
+    @Override
+    void throwPostLockException() {
+        throw new Exception("postlock")
+    }
+
+    Object getProperty(String property){
+        Namespace namespace = namespaces.find{ n ->
+            n.getName() == property
+        }
+        if(!namespace){
+            throw new AbortException("JTE does not have a primitive namespace for ${property}")
+        }
+        return namespace
+    }
+
+    Namespace getNamespace(String name){
+        return namespaces.find{ n -> n.getName() == name }
+    }
+
+    void addNamespace(Namespace namespace){
+        if(getNamespace(namespace.getName())){
+            throw new Exception("JTE already has primitive namespace ${namespace.getName()}")
+        }
+        namespaces.push(namespace)
+    }
+
+    static abstract class Namespace implements Serializable{
+        private static final long serialVersionUID = 1L
+        String name
+        abstract void push(TemplatePrimitive primitive)
+    }
+
+}

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
@@ -97,4 +97,13 @@ class TemplateBinding extends Binding implements Serializable{
         throw new TemplateException("No step ${stepName} has been loaded")
     }
 
+    List<TemplatePrimitive> getPrimitives(){
+        /**
+         * this intentionally does not use getVariable because the invocation of
+         * result.getValue() on TemplatePrimitives will throw a CpsCallableInvocation
+         * during JTE namespace population.
+         */
+        return registry.collect{ var -> variables.get(var) } as List<TemplatePrimitive>
+    }
+
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -15,6 +15,10 @@
 */
 package org.boozallen.plugins.jte.init.primitives
 
+import com.cloudbees.groovy.cps.NonCPS
+
+import java.lang.annotation.Inherited
+
 /**
  * Objects whose class extends TemplatePrimitive will be protected in the {@link TemplateBinding} from
  * being inadvertently overridden
@@ -33,4 +37,19 @@ abstract class TemplatePrimitive implements Serializable{
      */
     abstract void throwPostLockException()
 
+    /**
+     * implementation by each primitive must annotation this method with @NonCPS
+     * so that it can be invoked outside of pipeline execution during initialization
+     * @return
+     */
+    abstract Class getInjector()
+    Class injector
+
+    /**
+     * implementation by each primitive must annotation this method with @NonCPS
+     * so that it can be invoked outside of pipeline execution during initialization
+     * @return the name of the primitive in the binding
+     */
+    abstract String getName()
+    String name
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -34,14 +34,14 @@ abstract class TemplatePrimitive implements Serializable{
     abstract void throwPostLockException()
 
     /**
-     * implementation by each primitive must annotation this method with @NonCPS
+     * implementation by each primitive must annotate this method with @NonCPS
      * so that it can be invoked outside of pipeline execution during initialization
      * @return
      */
     abstract Class getInjector()
 
     /**
-     * implementation by each primitive must annotation this method with @NonCPS
+     * implementation by each primitive must annotate this method with @NonCPS
      * so that it can be invoked outside of pipeline execution during initialization
      * @return the name of the primitive in the binding
      */

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -15,10 +15,6 @@
 */
 package org.boozallen.plugins.jte.init.primitives
 
-import com.cloudbees.groovy.cps.NonCPS
-
-import java.lang.annotation.Inherited
-
 /**
  * Objects whose class extends TemplatePrimitive will be protected in the {@link TemplateBinding} from
  * being inadvertently overridden
@@ -43,7 +39,6 @@ abstract class TemplatePrimitive implements Serializable{
      * @return
      */
     abstract Class getInjector()
-    Class injector
 
     /**
      * implementation by each primitive must annotation this method with @NonCPS
@@ -51,5 +46,5 @@ abstract class TemplatePrimitive implements Serializable{
      * @return the name of the primitive in the binding
      */
     abstract String getName()
-    String name
+
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
@@ -74,6 +74,11 @@ abstract class TemplatePrimitiveInjector implements ExtensionPoint{
      * @param primitive
      */
     static void populateNamespace(JteNamespace jte, TemplatePrimitive primitive){}
+
+    /**
+     * Returns the name of the block the injector parses to create TemplatePrimitives
+     * @return
+     */
     static String getKey(){ return null }
 
     /**

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
@@ -19,6 +19,8 @@ import hudson.ExtensionList
 import hudson.ExtensionPoint
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
+import org.boozallen.plugins.jte.init.primitives.JteNamespace.Namespace
+import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.cps.CpsGroovyShellFactory
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
@@ -64,6 +66,15 @@ abstract class TemplatePrimitiveInjector implements ExtensionPoint{
         }
         return returnClass
     }
+
+    /**
+     * this extension exists to give injectors the opportunity to customize
+     * how they populate the namespace
+     * @param jte
+     * @param primitive
+     */
+    static void populateNamespace(JteNamespace jte, TemplatePrimitive primitive){}
+    static String getKey(){ return null }
 
     /**
      * parse the aggregated pipeline configuration to instantiate a {@link TemplatePrimitive} and store it in

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
@@ -18,6 +18,9 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.Extension
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
+import org.boozallen.plugins.jte.init.primitives.JteNamespace
+import org.boozallen.plugins.jte.init.primitives.JteNamespace.Namespace
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
@@ -33,13 +36,48 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
         return parseClass(classText)
     }
 
+    static void populateNamespace(JteNamespace jte, TemplatePrimitive primitive){
+        Namespace n = jte.getNamespace(key)
+        if(!n) {
+            // namespace doesn't exist yet.. create, push primitive, add
+            n = new ApplicationEnvironmentNamespace()
+            n.push(primitive)
+            jte.addNamespace(n)
+        } else if(!(n instanceof ApplicationEnvironmentNamespace)){
+            // namespace exists but isn't from this injector somehow?
+            throw new Exception("JTE Namespace conflict for name: ${key}")
+        } else {
+            // namespace exists.. just add primitive
+            n.push(primitive)
+        }
+    }
+
+    static class ApplicationEnvironmentNamespace extends Namespace {
+        String name = getKey()
+        LinkedHashMap primitives = [:]
+        @Override void push(TemplatePrimitive primitive){
+            String name = primitive.getName()
+            primitives[name] = primitive
+        }
+        Object getProperty(String name){
+            if(!primitives.containsKey(name)){
+                throw new Exception("Application Environment ${name} not found")
+            }
+            return primitives[name]
+        }
+    }
+
+    static String getKey(){ return "application_environments" }
+
     @SuppressWarnings('NoDef')
     @Override
     void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class appEnvClass = getPrimitiveClass()
-        ArrayList createdEnvs = []
-        config.getConfig().application_environments.each{ name, appEnvConfig ->
-            def env = appEnvClass.newInstance(name, appEnvConfig)
+        LinkedHashMap aggregatedConfig = config.getConfig()
+        def appEnvs = aggregatedConfig[key]
+        List createdEnvs = []
+        appEnvs.each{ name, appEnvConfig ->
+            def env = appEnvClass.newInstance(name, appEnvConfig, this.getClass())
             createdEnvs << env
             binding.setVariable(name, env)
         }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
@@ -18,6 +18,9 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.Extension
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
+import org.boozallen.plugins.jte.init.primitives.JteNamespace
+import org.boozallen.plugins.jte.init.primitives.JteNamespace.Namespace
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
@@ -33,11 +36,50 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
         return parseClass(classText)
     }
 
+    static void populateNamespace(JteNamespace jte, TemplatePrimitive primitive){
+        Namespace n = jte.getNamespace(key)
+        if(!n) {
+            // namespace doesn't exist yet.. create, push primitive, add
+            n = new KeywordNamespace()
+            n.push(primitive)
+            jte.addNamespace(n)
+        } else if(!(n instanceof KeywordNamespace)){
+            // namespace exists but isn't from this injector somehow?
+            throw new Exception("JTE Namespace conflict for name: ${key}")
+        } else {
+            // namespace exists.. just add primitive
+            n.push(primitive)
+        }
+    }
+
+    static class KeywordNamespace extends Namespace {
+        String name = getKey()
+        LinkedHashMap primitives = [:]
+        @Override void push(TemplatePrimitive primitive){
+            String name = primitive.getName()
+            primitives[name] = primitive.getValue()
+        }
+        Object getProperty(String name){
+            if(!primitives.containsKey(name)){
+                throw new Exception("Keyword ${name} not found")
+            }
+            return primitives[name]
+        }
+    }
+
+    static String getKey(){ return "keywords" }
+
     @Override
     void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class keywordClass = getPrimitiveClass()
-        config.getConfig().keywords.each{ key, value ->
-            binding.setVariable(key, keywordClass.newInstance(keyword: key, value: value))
+        LinkedHashMap aggregatedConfig = config.getConfig()
+        def keywords = aggregatedConfig[key]
+        keywords.each{ name, value ->
+            binding.setVariable(name, keywordClass.newInstance(
+                name: name,
+                value: value,
+                injector: this.getClass()
+            ))
         }
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
@@ -17,7 +17,11 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 
 import hudson.Extension
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
+import org.boozallen.plugins.jte.init.primitives.JteNamespace
+import org.boozallen.plugins.jte.init.primitives.JteNamespace.Namespace
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
+import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 /**
@@ -26,19 +30,47 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
  */
 @Extension class PipelineConfigVariableInjector extends TemplatePrimitiveInjector {
 
-    static final String VARIABLE = "pipelineConfig"
+    static void populateNamespace(JteNamespace jte, TemplatePrimitive primitive){
+        Namespace n = jte.getNamespace(key)
+        if(!n) {
+            // namespace doesn't exist yet.. create, push primitive, add
+            n = new PipelineConfigNamespace()
+            n.push(primitive)
+            jte.addNamespace(n)
+        } else if(!(n instanceof PipelineConfigNamespace)){
+            // namespace exists but isn't from this injector somehow?
+            throw new Exception("JTE Namespace conflict for name: ${key}")
+        } else {
+            // namespace exists.. just add primitive
+            n.push(primitive)
+        }
+    }
+
+    static class PipelineConfigNamespace extends Namespace {
+        String name = getKey()
+        LinkedHashMap pipelineConfig
+        @Override void push(TemplatePrimitive primitive){
+            pipelineConfig = primitive.getValue()
+        }
+        Object getProperty(String name){
+            return pipelineConfig[name]
+        }
+    }
+
+    static String getKey(){ return "pipelineConfig" }
 
     @SuppressWarnings('NoDef')
     @Override
     void doInject(FlowExecutionOwner flowOwner, PipelineConfigurationObject config, Binding binding){
         Class keywordClass = KeywordInjector.getPrimitiveClass()
         def pipelineConfig = keywordClass.newInstance(
-            keyword: VARIABLE,
+            name: getKey(),
+            injector: this.getClass(),
             value: config.getConfig(),
-            preLockException: "Variable ${VARIABLE} reserved for accessing the aggregated pipeline configuration",
-            postLockException: "Variable ${VARIABLE} reserved for accessing the aggregated pipeline configuration"
+            preLockException: "Variable ${getKey()} reserved for accessing the aggregated pipeline configuration",
+            postLockException: "Variable ${getKey()} reserved for accessing the aggregated pipeline configuration"
         )
-        binding.setVariable(VARIABLE, pipelineConfig)
+        binding.setVariable(getKey(), pipelineConfig)
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperFactory.groovy
@@ -167,7 +167,8 @@ class StepWrapperFactory{
             config: config,
             sourceText: sourceText,
             // parse to fail fast for step compilation issues
-            script: prepareScript(library, name, sourceText, binding, config)
+            script: prepareScript(library, name, sourceText, binding, config),
+            injector: LibraryLoader
         )
     }
 
@@ -191,7 +192,8 @@ class StepWrapperFactory{
             config: config,
             sourceFile: filePath.absolutize().getRemote(),
             // parse to fail fast for step compilation issues
-            script: prepareScript(library, name, sourceText, binding, config)
+            script: prepareScript(library, name, sourceText, binding, config),
+            injector: LibraryLoader
         )
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/util/SandboxWhitelist.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/SandboxWhitelist.groovy
@@ -17,6 +17,7 @@ package org.boozallen.plugins.jte.util
 
 import hudson.Extension
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AbstractWhitelist
+import org.boozallen.plugins.jte.init.primitives.JteNamespace.Namespace
 
 import java.lang.reflect.Method
 
@@ -25,21 +26,23 @@ import java.lang.reflect.Method
  */
 @Extension class SandboxWhitelist extends AbstractWhitelist {
 
-    private final ArrayList permittedReceivers = [
+    private final ArrayList permittedReceiverStrings = [
         "org.boozallen.plugins.jte.init.primitives.injectors.ApplicationEnvironment",
         "org.boozallen.plugins.jte.init.primitives.injectors.StepWrapper",
         "org.boozallen.plugins.jte.init.primitives.injectors.Stage",
-        "org.boozallen.plugins.jte.init.primitives.hooks.Hooks"
+        "org.boozallen.plugins.jte.init.primitives.hooks.Hooks",
+        "org.boozallen.plugins.jte.init.primitives.JteNamespace"
     ]
 
     @Override
     boolean permitsMethod(Method method, Object receiver, Object[] args) {
-        return receiver.getClass().getName() in permittedReceivers
+        return (receiver in Namespace || receiver.getClass().getName() in permittedReceiverStrings)
     }
 
     @Override
     boolean permitsStaticMethod(Method method, Object[] args){
-        return method.getDeclaringClass().getName() in permittedReceivers
+        Class receiver = method.getDeclaringClass()
+        return (receiver in Namespace || receiver.getName() in permittedReceiverStrings)
     }
 
 }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironment.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironment.groovy
@@ -15,6 +15,7 @@
 */
 package org.boozallen.plugins.jte.init.primitives.injectors
 
+import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.init.governance.config.dsl.TemplateConfigException
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
@@ -26,20 +27,24 @@ import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
 
     private static final long serialVersionUID = 1L
-    String varName
+    String name
+    Class injector
     String short_name
     String long_name
     def config
     ApplicationEnvironment previous
     ApplicationEnvironment next
 
+    @NonCPS @Override String getName(){ return name }
+    @NonCPS @Override Class getInjector(){ return ApplicationEnvironmentInjector }
+
     ApplicationEnvironment(){}
 
-    ApplicationEnvironment(String varName, Map config){
-        this.varName = varName
-
-        short_name = config.short_name ?: varName
-        long_name = config.long_name ?: varName
+    ApplicationEnvironment(String name, Map config, Class injector){
+        this.injector = injector
+        this.name = name
+        this.short_name = config.short_name ?: name
+        this.long_name = config.long_name ?: name
 
         /*
             users cant define the previous or next properties. they'll
@@ -48,7 +53,7 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
 
         def context = config.subMap(["previous", "next"])
         if(context){
-            throw new TemplateConfigException("""Error configuring ApplicationEnvironment ${varName}
+            throw new TemplateConfigException("""Error configuring ApplicationEnvironment ${name}
             The previous and next configuration options are reserved and auto-populated.
             """.stripIndent())
         }
@@ -74,11 +79,11 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
     }
 
     void throwPreLockException(){
-        throw new TemplateException ("Application Environment ${varName} already defined.")
+        throw new TemplateException ("Application Environment ${name} already defined.")
     }
 
     void throwPostLockException(){
-        throw new TemplateException ("Variable ${varName} is reserved as an Application Environment.")
+        throw new TemplateException ("Variable ${name} is reserved as an Application Environment.")
     }
 
 }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
@@ -15,6 +15,7 @@
 */
 package org.boozallen.plugins.jte.init.primitives.injectors
 
+import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 
@@ -24,12 +25,16 @@ import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 class Keyword extends TemplatePrimitive implements Serializable{
 
     private static final long serialVersionUID = 1L
-    String keyword
     Object value
-    String preLockException = "Variable ${keyword} already exists as a Keyword."
-    String postLockException = "Variable ${keyword} is reserved as a template Keyword."
+    String name
+    Class injector
+    String preLockException = "Variable ${name} already exists as a Keyword."
+    String postLockException = "Variable ${name} is reserved as a template Keyword."
 
-    Object getValue(){
+    @NonCPS @Override String getName(){ return name }
+    @NonCPS @Override Class getInjector(){ return injector }
+
+    @NonCPS Object getValue(){
         return value
     }
 

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -15,6 +15,7 @@
 */
 package org.boozallen.plugins.jte.init.primitives.injectors
 
+import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
@@ -28,17 +29,13 @@ import org.boozallen.plugins.jte.util.TemplateLogger
 class Stage extends TemplatePrimitive implements Serializable{
 
     private static final long serialVersionUID = 1L
+    Class injector
     Binding binding
     String name
     ArrayList<String> steps
 
-    Stage(){}
-
-    Stage(Binding binding, String name, ArrayList<String> steps){
-        this.binding = binding
-        this.name = name
-        this.steps = steps
-    }
+    @NonCPS Class getInjector(){ return injector }
+    @NonCPS String getName(){ return name }
 
     @SuppressWarnings("MethodParameterTypeRequired")
     void call(args) {

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -45,12 +45,12 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
     /**
      * The name of the step
      */
-    private String name
+    String name
 
     /**
      * The name of the library that's contributed the step
      */
-    private String library
+    String library
 
     /**
      * The library configuration
@@ -86,7 +86,14 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
      */
     private HookContext hookContext
 
-    @NonCPS String getName(){ return name }
+    /**
+     * The injector responsible for putting this StepWrapper into
+     * the TemplateBinding
+     */
+    Class injector
+
+    @NonCPS @Override Class getInjector(){ return injector }
+    @NonCPS @Override String getName(){ return name }
     @NonCPS String getLibrary(){ return library }
 
     /**

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/defaultStepImplementation.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/defaultStepImplementation.groovy
@@ -58,7 +58,7 @@ void call(){
             } catch(ignore){}
 
             // validate only one of command or script is set
-            if (!config.subMap(["command", "script"]).size() == 1) {
+            if (!(config.subMap(["command", "script"]).size() == 1)) {
                 error error_msg
             }
 


### PR DESCRIPTION
# PR Details

- Create a `jte` variable that serves as a namespace to directly invoke loaded primitives. 
- Each `TemplatePrimitiveInjector` is able to subclass their own `Namespace` to handle storage/exception handling for their own primitives. 

# Validation

<details><summary>Pipeline Configuration</summary>
<p>

```groovy
application_environments{
  dev
  test{
    randomField = 11
  }
}

stages{
  ci{
    a
    b
    c
  }
}

libraries{
  gradle
  sonarqube
}

keywords{
  myKeyword = "myValue"
  other = "other"
}

randomBlock{
  randomField = "hey"
}
```

</p>
</details>

<details><summary>Pipeline Template</summary>
<p>

```groovy
println "---"

// test app envs
assert dev == jte.application_environments.dev
assert 11 == jte.application_environments.test.randomField

// test keywords
assert "myValue" == jte.keywords.myKeyword
assert "other" == jte.keywords.other

// test pipelineConfig
assert jte.pipelineConfig.randomBlock == [ randomField: "hey" ]
assert jte.pipelineConfig.randomBlock.randomField == "hey"

// test stages
assert ci == jte.stages.ci

// test libraries
assert build == jte.libraries.gradle.build
assert static_code_analysis == jte.libraries.sonarqube.static_code_analysis
```

</p>
</details>

## To Do

* How do we want to handle default step implementations?  Could create a `jte.steps` namespace?
* Need to add unit tests that more or less mimic those validations above 