### PR TITLE
Fixes Resumability Bug - #158

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'groovy'
-  id 'org.jenkins-ci.jpi' version '0.39.0'
+  id 'org.jenkins-ci.jpi' version '0.42.0'
   id 'jacoco'
   id "com.diffplug.gradle.spotless" version "3.29.0"
   id 'codenarc'
@@ -60,7 +60,10 @@ dependencies {
         exclude(module: 'annotation-indexer')
     }
 
+    testImplementation(group: "org.jenkins-ci.main", name: "jenkins-test-harness", version: "2.71")
+
     // test plugins
+    testImplementation(group: "org.jenkins-ci.plugins.workflow", name: "workflow-support", classifier: "tests")
     testImplementation(group: "org.jenkins-ci.plugins", name: "scm-api", version: "2.3.0", classifier: "tests")
     testImplementation(group: 'org.jenkins-ci.plugins', name: 'git', version:'3.9.3') {
         exclude(module: 'httpclient')

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 group = 'org.jenkins-ci.plugins'
-version = '2.0.1'
+version = '2.0.2'
 description = 'Allows users to create tool-agnostic, templated pipelines to be shared by multiple teams'
 
 jenkinsPlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ jacocoTestReport {
 
 spotless{
     groovy{
-        target = fileTree("src/main/groovy") + fileTree(dir: "src/main/resources", include: "**/*.groovy")
+        target = fileTree("src/main/groovy") + fileTree(dir: "src/main/resources", include: "**/*.groovy") + fileTree("src/test/groovy")
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
@@ -49,7 +49,7 @@ class PipelineDecorator extends InvisibleAction implements Serializable {
 
     FlowExecutionOwner flowOwner
     PipelineConfigurationObject config
-    transient TemplateBinding binding
+    TemplateBinding binding
     String template
 
     PipelineDecorator(FlowExecutionOwner flowOwner) {

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
@@ -15,12 +15,17 @@
 */
 package org.boozallen.plugins.jte.init.primitives
 
+import org.boozallen.plugins.jte.init.PipelineDecorator
 import org.boozallen.plugins.jte.init.primitives.injectors.StepWrapperFactory
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.jenkinsci.plugins.workflow.cps.DSL
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
+import org.jenkinsci.plugins.workflow.cps.CpsThread
+import org.jenkinsci.plugins.workflow.flow.FlowExecution
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 /**
  * Stores a run's primitives
@@ -151,6 +156,15 @@ class TemplateBinding extends Binding implements Serializable{
      */
     Set<String> getPrimitiveNames(){
         return this.registry.getVariables()
+    }
+
+    static TemplateBinding fetchDuringRun(){
+        CpsThread thread = CpsThread.current()
+        FlowExecution execution = thread?.getExecution()
+        FlowExecutionOwner owner = execution?.getOwner()
+        WorkflowRun run = owner.run()
+        PipelineDecorator decorator = run.getAction(PipelineDecorator)
+        return decorator.getBinding()
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
@@ -24,7 +24,6 @@ import org.jenkinsci.plugins.workflow.cps.DSL
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.cps.CpsThread
 import org.jenkinsci.plugins.workflow.flow.FlowExecution
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 /**
@@ -53,6 +52,15 @@ class TemplateBinding extends Binding implements Serializable{
          * that would be triggered by "jte" as a ReservedVariableName
          */
         variables.put(registry.getVariableName(), registry)
+    }
+
+    static TemplateBinding fetchDuringRun(){
+        CpsThread thread = CpsThread.current()
+        FlowExecution execution = thread?.getExecution()
+        FlowExecutionOwner owner = execution?.getOwner()
+        WorkflowRun run = owner.run()
+        PipelineDecorator decorator = run.getAction(PipelineDecorator)
+        return decorator.getBinding()
     }
 
     void lock(FlowExecutionOwner flowOwner){
@@ -156,15 +164,6 @@ class TemplateBinding extends Binding implements Serializable{
      */
     Set<String> getPrimitiveNames(){
         return this.registry.getVariables()
-    }
-
-    static TemplateBinding fetchDuringRun(){
-        CpsThread thread = CpsThread.current()
-        FlowExecution execution = thread?.getExecution()
-        FlowExecutionOwner owner = execution?.getOwner()
-        WorkflowRun run = owner.run()
-        PipelineDecorator decorator = run.getAction(PipelineDecorator)
-        return decorator.getBinding()
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StageInjector.groovy
@@ -58,7 +58,6 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
         aggregatedConfig[KEY].each{ name, steps ->
             List<String> stepNames = steps.keySet() as List<String>
             binding.setVariable(name, stageClass.newInstance(
-                binding: binding,
                 name: name,
                 steps: stepNames,
                 injector: this.getClass()

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -18,6 +18,7 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import com.cloudbees.groovy.cps.NonCPS
 import org.boozallen.plugins.jte.init.primitives.TemplateException
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
+import org.boozallen.plugins.jte.init.primitives.TemplateBinding
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.TemplateLogger
@@ -30,15 +31,13 @@ import org.boozallen.plugins.jte.util.TemplateLogger
 class Stage extends TemplatePrimitive implements Serializable{
 
     private static final long serialVersionUID = 1L
-    Binding binding
     String name
     Class<? extends TemplatePrimitiveInjector> injector
     ArrayList<String> steps
 
     Stage(){}
 
-    Stage(Binding binding, String name, ArrayList<String> steps){
-        this.binding = binding
+    Stage(String name, ArrayList<String> steps){
         this.name = name
         this.steps = steps
     }
@@ -55,7 +54,7 @@ class Stage extends TemplatePrimitive implements Serializable{
         } else {
             stageArgs = args as Map
         }
-
+        TemplateBinding binding = TemplateBinding.fetchDuringRun()
         StageContext stageContext = new StageContext(name: name, args: stageArgs)
         steps.each{ step ->
             def clone = binding.getStep(step).clone()

--- a/src/test/groovy/org/boozallen/plugins/jte/init/ResumabilitySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/ResumabilitySpec.groovy
@@ -1,0 +1,65 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+package org.boozallen.plugins.jte.init
+
+import org.boozallen.plugins.jte.init.PipelineDecorator
+import org.junit.Rule
+import org.jvnet.hudson.test.RestartableJenkinsRule
+import org.jvnet.hudson.test.WithoutJenkins
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import org.junit.runners.model.Statement
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+
+
+class ResumabilitySpec extends Specification{
+
+    @Rule RestartableJenkinsRule story = new RestartableJenkinsRule()
+
+    def "Pipeline resumes after graceful restart"(){
+        when: 
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("""
+                println "running before sleep"
+                sleep 15
+                println "running after sleep"
+                """))
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                // SemaphoreStep.waitForStart("wait/1", b);
+                story.j.waitForMessage("running before sleep", b);
+            }
+        });
+
+        then: 
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                // SemaphoreStep.success("wait/1", null);
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                WorkflowRun b = p.getLastBuild();
+                story.j.assertLogContains("running after sleep", story.j.waitForCompletion(b));
+            }
+        });
+    }
+
+    def "Stages succeed after pipeline graceful restart"(){}
+    def "Steps succeed after pipeline graceful restart"(){}
+
+}

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Booz Allen Hamilton
+    Copyright 2018 Booz Allen Hamilton
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/JteBlockValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/JteBlockValidatorSpec.groovy
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Booz Allen Hamilton
+    Copyright 2018 Booz Allen Hamilton
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableSpec.groovy
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Booz Allen Hamilton
+    Copyright 2018 Booz Allen Hamilton
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
@@ -1,3 +1,18 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
 package org.boozallen.plugins.jte.job
 
 import hudson.model.TaskListener

--- a/src/test/groovy/org/boozallen/plugins/jte/util/TestUtil.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/util/TestUtil.groovy
@@ -32,8 +32,8 @@ class TestUtil{
      * @param args named parameters.  template and config expected keys
      * @param jenkins the JenkinsRule for the test
      */
-    static WorkflowJob createAdHoc(LinkedHashMap args, JenkinsRule jenkins){
-        WorkflowJob job = jenkins.createProject(WorkflowJob)
+    static WorkflowJob createAdHoc(LinkedHashMap args, JenkinsRule jenkins, String name){
+        WorkflowJob job =  name ? jenkins.createProject(WorkflowJob, name) : jenkins.createProject(WorkflowJob)
         ConsolePipelineConfiguration pipelineConfig = new ConsolePipelineConfiguration(args.containsKey("config"), args.config)
         ConsoleDefaultPipelineTemplate pipelineTemplate = new ConsoleDefaultPipelineTemplate(args.containsKey("template"), args.template)
         def templateConfiguration = new ConsoleAdHocTemplateFlowDefinitionConfiguration(pipelineTemplate, pipelineConfig)

--- a/src/test/groovy/org/boozallen/plugins/jte/util/TestUtil.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/util/TestUtil.groovy
@@ -32,7 +32,7 @@ class TestUtil{
      * @param args named parameters.  template and config expected keys
      * @param jenkins the JenkinsRule for the test
      */
-    static WorkflowJob createAdHoc(LinkedHashMap args, JenkinsRule jenkins, String name){
+    static WorkflowJob createAdHoc(LinkedHashMap args, JenkinsRule jenkins, String name = null){
         WorkflowJob job =  name ? jenkins.createProject(WorkflowJob, name) : jenkins.createProject(WorkflowJob)
         ConsolePipelineConfiguration pipelineConfig = new ConsolePipelineConfiguration(args.containsKey("config"), args.config)
         ConsoleDefaultPipelineTemplate pipelineTemplate = new ConsoleDefaultPipelineTemplate(args.containsKey("template"), args.template)


### PR DESCRIPTION
# PR Details

fixes #158 describing a bug in JTE resumability.  This PR resolves that bug. 

## Description

`GroovyShellDecoratorImpl` rehydrates the run's populated `TemplateBinding` by fetching it from the `PipelineDecorator` action.  For some reason, the `TemplateBinding` on the action had been set to transient -- resulting in a `null` binding on restart.

## How Has This Been Tested

Unit tests

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
