### PR TITLE
Fix bug in how PluginLibraryProvider reads jar contents - #168

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -84,7 +84,7 @@ class PluginLibraryProvider extends LibraryProvider{
 
                 String thing = parts[2]
                 if(thing == CONFIG_FILE){
-                    libraries[libName] = getFileContents(zipFile, zipEntry)
+                    libraries[libName].config = getFileContents(zipFile, zipEntry)
                 } else if (thing in [ "steps", "resources"]){
                     String relativePath = path - "libraries/${libName}/"
                     libraries[libName][thing][relativePath] = getFileContents(zipFile, zipEntry)

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -85,7 +85,7 @@ class PluginLibraryProvider extends LibraryProvider{
                 String thing = parts[2]
                 if(thing == CONFIG_FILE){
                     libraries[libName].config = getFileContents(zipFile, zipEntry)
-                } else if (thing in [ "steps", "resources"]){
+                } else if (thing in [ "steps", "resources"] && !path.endsWith('/')){
                     String relativePath = path - "libraries/${libName}/"
                     libraries[libName][thing][relativePath] = getFileContents(zipFile, zipEntry)
                 }


### PR DESCRIPTION
# PR Details

fixes #168.

## Description

When parsing the jar file and reading it's contents, JTE isn't handling `library_config.goovy` files or directory entries properly.

## How Has This Been Tested

I rebuilt JTE with the changes and loaded it into my local Jenkins environment and confirmed that it would proceed past that point.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
