### PR TITLE
Resolve #174

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationDsl.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationDsl.groovy
@@ -20,6 +20,8 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.kohsuke.groovy.sandbox.SandboxTransformer
 
+import java.util.regex.Pattern
+
 /**
  * Parses the pipeline configuration DSL into a {@link PipelineConfigurationObject}
  */
@@ -109,6 +111,9 @@ class PipelineConfigurationDsl {
                     break
                 case List:
                     appendedFile += "${tab * depth}${merge}${override}${key} = ${value.inspect()}"
+                    break
+                case Pattern:
+                    appendedFile += "${tab * depth}${merge}${override}${key} = ~/${value}/"
                     break
                 default:
                     appendedFile += "${tab * depth}${merge}${override}${key} = ${value}"

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationObjectSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationObjectSpec.groovy
@@ -20,6 +20,7 @@ import org.boozallen.plugins.jte.util.TestUtil
 import org.jenkinsci.plugins.workflow.cps.EnvActionImpl
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import spock.lang.IgnoreRest
 import spock.lang.Specification
 
 class PipelineConfigurationObjectSpec extends Specification {
@@ -527,6 +528,23 @@ class PipelineConfigurationObjectSpec extends Specification {
             "Subsequent May Merge: None",
             "Subsequent May Override: None"
         ])
+    }
+
+    def "GitHub Issue #174"() {
+        given:
+        String config = """
+        keywords{
+          master = ~/[Mm](aster|ain)/
+        }
+        """
+        PipelineConfigurationObject obj = dsl.parse(config)
+
+        when:
+        String serialized = dsl.serialize(obj)
+        dsl.parse(serialized)
+
+        then:
+        noExceptionThrown()
     }
 
 }

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationObjectSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/dsl/PipelineConfigurationObjectSpec.groovy
@@ -20,7 +20,6 @@ import org.boozallen.plugins.jte.util.TestUtil
 import org.jenkinsci.plugins.workflow.cps.EnvActionImpl
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
-import spock.lang.IgnoreRest
 import spock.lang.Specification
 
 class PipelineConfigurationObjectSpec extends Specification {


### PR DESCRIPTION
# PR Details

This PR fixes #174 

## Description

Was seeing a situation where having more than pipeline configuration was throwing an exception, specifically: 
```
groovy.lang.MissingMethodException: No signature of method: org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationBuilder$BuilderMethod.or() is applicable for argument types: (org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationBuilder$BuilderMethod) values: [PROPERTY_MISSING]
```

The root cause of this was improperly serialized pipeline configuration. Specifically, having a regular expression pattern that used regex groups. 

For this specific use case, the offending line was `master = ~/[Mm](aster|ain)/`. 

In JTE, when aggregating two pipeline configurations, we create a copy of the current and incoming pipeline configuration objects by serializing the object back to it's groovy DSL representation and then re-parsing  it to create the deep copy. 

When serialized, the Pattern `~/[Mm](aster|ain)/` gets written as `[Mm](aster|ain)`. 

When that is parsed, the parenthesis are executed as code so `aster` and `ain` are considered properties to be fetched and return an internal facing enum called `BuilderMethod.PROPERTY_MISSING`. 

the `|` operator is a shorthand for invoking the `or()` method. 

so the user facing exception that was thrown was the result of invoking `(aster|ain)` as the configuration language DSL, which could be said another way as `BuilderMethod.PROPERTY_MISSING.or(BuilderMethod.PROPERTY_MISSING)`

The fix was to add a special case to the serialize to appropriately handle `Pattern` objects. 

## How Has This Been Tested

Unit Tests confirmed the fix

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
