### PR TITLE
hasLibrary is true if steps or src present

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -124,12 +124,11 @@ class PluginLibraryProvider extends LibraryProvider{
         }
 
         Boolean hasSteps = (libraries[libName])?.steps as Boolean
-        if( !hasSteps ){ // library has no steps
+        Boolean hasClasses = (libraries[libName])?.src as Boolean
+
+        if( !hasSteps || !hasClasses){ // library has no steps
             TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-            ArrayList msg = [
-                    "Library ${libName} exists but does not have steps present. No steps will be loaded."
-            ]
-            logger.printWarning(msg.join("\n"))
+            logger.printWarning("Library ${libName} exists but deos not have any steps or classes. Will not be loaded.")
             return false
         }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -128,7 +128,7 @@ class PluginLibraryProvider extends LibraryProvider{
 
         if( !hasSteps || !hasClasses){ // library has no steps
             TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-            logger.printWarning("Library ${libName} exists but deos not have any steps or classes. Will not be loaded.")
+            logger.printWarning("Library ${libName} exists but does not have any steps or classes. Will not be loaded.")
             return false
         }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
@@ -65,27 +65,16 @@ class ScmLibraryProvider extends LibraryProvider{
         }
 
         SCMFile stepsDir = lib.child(LibraryProvider.STEPS_DIR_NAME)
-        boolean hasValidStepsDir = null != stepsDir && stepsDir.isDirectory()
+        boolean hasSteps = null != stepsDir && stepsDir.isDirectory()
 
-        // must have a steps dir with at least one step file *.groovy
-        if( hasValidStepsDir ){
-            hasValidStepsDir = false
-            recurseChildren(stepsDir){ file ->
-                if(file.getName().endsWith(".groovy")){
-                    hasValidStepsDir = true
-                    return true
-                }
-            }
-        }
+        SCMFile srcDir = lib.child(LibraryProvider.SRC_DIR_NAME)
+        boolean hasClasses = null != srcDir && srcDir.isDirectory()
 
-        if( !hasValidStepsDir ){
+        if( !hasSteps && !hasClasses ){
             TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-            ArrayList msg = [
-                    "Library ${libName} exists but does not have steps present under a 'steps' directory. No steps will be loaded."
-            ]
-            logger.printWarning(msg.join("\n"))
+            logger.printWarning("Library ${libName} exists but does not have a '${LibraryProvider.STEPS_DIR_NAME}' or '${LibraryProvider.SRC_DIR_NAME}' directory. Library will not be loaded.")
         }
-        return hasValidStepsDir
+        return (hasSteps || hasClasses)
     }
 
     @Override

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
@@ -97,48 +97,6 @@ class ScmLibraryProviderSpec extends Specification{
         p.hasLibrary(owner, libraryName)
     }
 
-    def "hasLibrary returns false when library exists but has no steps directory"(){
-        given:
-        ScmLibraryProvider p = new ScmLibraryProvider()
-        String libraryName = "someLibrary"
-        repo.init()
-        repo.write("${libraryName}/resources/someStep.groovy", "void call(){ println 'the step' }")
-        repo.git("add", "*")
-        repo.git("commit", "--message=init")
-        GitSCM scm = createSCM(repo)
-        p.setScm(scm)
-
-        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
-        1 * logger.println{ msg -> msg.contains("Library ${libraryName} exists but does not have steps present".toString()) }
-
-        expect:
-        p.hasLibrary(owner, libraryName) == false
-    }
-
-    def "hasLibrary returns false when library step directory exists but has no steps *.groovy"(){
-        given:
-        ScmLibraryProvider p = new ScmLibraryProvider()
-        String libraryName = "someLibrary"
-        repo.init()
-        repo.write("${libraryName}/steps/someStep.sh", "void call(){ println 'the step' }")
-        repo.git("add", "*")
-        repo.git("commit", "--message=init")
-        GitSCM scm = createSCM(repo)
-        p.setScm(scm)
-
-        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
-        1 * logger.println{ msg -> msg.contains("Library ${libraryName} exists but does not have steps present".toString()) }
-
-        expect:
-        p.hasLibrary(owner, libraryName) == false
-    }
-
     def "hasLibrary returns false when library does not exist"(){
         given:
         ScmLibraryProvider p = new ScmLibraryProvider()
@@ -284,6 +242,103 @@ class ScmLibraryProviderSpec extends Specification{
 
         then:
         thrown(JTEException)
+    }
+
+    def "hasLibrary returns true when only src directory present"(){
+        given:
+        ScmLibraryProvider p = new ScmLibraryProvider()
+        String libraryName = "someLibrary"
+        repo.init()
+        repo.write("${libraryName}/src/boozallen/Utility.groovy", "package boozallen; class Utility{} ")
+        repo.git("add", "*")
+        repo.git("commit", "--message=init")
+        GitSCM scm = createSCM(repo)
+        p.setScm(scm)
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        File rootDir = new File(f.getRemote())
+        owner.getRootDir() >> rootDir
+        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
+        fsw.fs = SCMFileSystem.of(job, scm)
+        GroovySpy(FileSystemWrapper, global: true)
+        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+
+        expect:
+        p.hasLibrary(owner, libraryName)
+    }
+
+    def "hasLibrary returns true when only steps directory present"(){
+        given:
+        ScmLibraryProvider p = new ScmLibraryProvider()
+        String libraryName = "someLibrary"
+        repo.init()
+        repo.write("${libraryName}/steps/build.groovy", "void call(){}")
+        repo.git("add", "*")
+        repo.git("commit", "--message=init")
+        GitSCM scm = createSCM(repo)
+        p.setScm(scm)
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        File rootDir = new File(f.getRemote())
+        owner.getRootDir() >> rootDir
+        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
+        fsw.fs = SCMFileSystem.of(job, scm)
+        GroovySpy(FileSystemWrapper, global: true)
+        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+
+        expect:
+        p.hasLibrary(owner, libraryName)
+    }
+
+    def "hasLibrary returns true when both steps and src are present"(){
+        given:
+        ScmLibraryProvider p = new ScmLibraryProvider()
+        String libraryName = "someLibrary"
+        repo.init()
+        repo.write("${libraryName}/src/boozallen/Utility.groovy", "package boozallen; class Utility{} ")
+        repo.write("${libraryName}/steps/build.groovy", "void call(){}")
+        repo.git("add", "*")
+        repo.git("commit", "--message=init")
+        GitSCM scm = createSCM(repo)
+        p.setScm(scm)
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        File rootDir = new File(f.getRemote())
+        owner.getRootDir() >> rootDir
+        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
+        fsw.fs = SCMFileSystem.of(job, scm)
+        GroovySpy(FileSystemWrapper, global: true)
+        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+
+        expect:
+        p.hasLibrary(owner, libraryName)
+    }
+
+    def "hasLibrary returns false if only resources directory present"(){
+        given:
+        ScmLibraryProvider p = new ScmLibraryProvider()
+        String libraryName = "someLibrary"
+        repo.init()
+        repo.write("${libraryName}/resources/boozallen/Utility.groovy", "package boozallen; class Utility{} ")
+        repo.git("add", "*")
+        repo.git("commit", "--message=init")
+        GitSCM scm = createSCM(repo)
+        p.setScm(scm)
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob)
+        FilePath f = jenkins.getInstance().getWorkspaceFor(job)
+        File rootDir = new File(f.getRemote())
+        owner.getRootDir() >> rootDir
+        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
+        fsw.fs = SCMFileSystem.of(job, scm)
+        GroovySpy(FileSystemWrapper, global: true)
+        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+
+        expect:
+        !p.hasLibrary(owner, libraryName)
     }
 
     GitSCM createSCM(GitSampleRepoRule _repo){


### PR DESCRIPTION
# PR Details

Previously, libraries would only be found if a populated `steps` directory was present. 

Now that libraries can contribute classes via the `src` directory, the criteria for finding a library has been updated. 

It is now possible for a library to only contribute classes or only contribute steps or both.  

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
