### PR TITLE
Fix JTE javadoc on the plugin site

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,3 +124,13 @@ sourceSets {
 groovydoc{
     source fileTree("src/main/groovy")
 }
+
+/**
+ * this is necessary so that the groovydocs show up as the javadocs
+ * on the jenkins plugin site
+ */
+task javadocJar(type: Jar) {
+    description "An archive of the JavaDocs for Maven Central"
+    classifier "javadoc"
+    from groovydoc
+}


### PR DESCRIPTION
# PR Details

Right now, the [JTE JavaDocs on the Plugin Site](https://javadoc.jenkins.io/plugin/templating-engine/) are only showing the contents of `src/main/java`. 

This PR updates the `build.groovy` file to override the default behavior of the `javadocJar` task to "trick" the plugin site into showing the groovydocs (which include the `src/main/java` content as well).

## How Has This Been Tested

I ran

> ./gradlew javadocJar

and then after switching to the `build/libs` directory, i exploded the javadoc jar file via:

> jar xf *-javadoc.jar

and then validated that `index.html` was the groovydocs vs the javadocs. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
