### PR TITLE
Stop storing non-serializable TemplatePrimitiveCollector in `StageCPS`

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveCollector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveCollector.groovy
@@ -97,10 +97,10 @@ class TemplatePrimitiveCollector extends InvisibleAction{
     }
 
     boolean hasStep(String name){
-        return getStep(name) as boolean
+        return getSteps(name) as boolean
     }
 
-    List<TemplatePrimitive> getStep(String name){
+    List<TemplatePrimitive> getSteps(String name){
         return findAll{ primitive ->
             primitive instanceof StepWrapper &&
             primitive.getName() == name

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
@@ -46,7 +46,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             if (primitiveCollector.hasStep(stepName)){
                 ArrayList msg = [
                     "Configured step ${stepName} ignored.",
-                    "-- Loaded by the ${primitiveCollector.getStep(stepName).library} Library."
+                    "-- Loaded by the ${primitiveCollector.getSteps(stepName).library} Library."
                 ]
                 logger.printWarning msg.join("\n")
             } else { // otherwise go ahead and create the default step implementation

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
@@ -15,6 +15,7 @@
 */
 package org.boozallen.plugins.jte.init.primitives.injectors
 
+import com.cloudbees.groovy.cps.NonCPS
 import groovy.transform.InheritConstructors
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
@@ -38,17 +39,22 @@ class StageCPS extends Stage{
         } else {
             stageArgs = args as Map
         }
-        TemplatePrimitiveCollector primitiveCollector = TemplatePrimitiveCollector.current()
         StageContext stageContext = new StageContext(name: getName(), args: stageArgs)
-        getSteps().each{ step ->
-            List<StepWrapper> s = primitiveCollector.getStep(step)
+        getSteps().each{ stepName ->
+            List<StepWrapper> s = this.getStepWrappers(stepName)
             if(s.size() > 1){
-                throw new JTEException("Found more than one step for '${step}'")
+                throw new JTEException("Found more than one step for '${stepName}'")
             }
-            StepWrapper clone = s.first()
+            StepWrapper clone = s.first().clone()
             clone.setStageContext(stageContext)
             clone.getValue().call()
         }
+    }
+
+    @NonCPS
+    List<StepWrapper> getStepWrappers(String stepName){
+        TemplatePrimitiveCollector primitiveCollector = TemplatePrimitiveCollector.current()
+        return primitiveCollector.getSteps(stepName)
     }
 
 }


### PR DESCRIPTION
# PR Details

Utilizes a `@NonCPS` method in `StagesCPS` to fetch `StepWrappers` for the stage's steps to prevent resumability issues when using stages. 

fixes #195 

## How Has This Been Tested

unit tests reproduced the issue and then confirmed the fix

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
