### PR TITLE
fix 205 by having TemplatePrimitiveNamespace override check isOverloaded

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
@@ -15,7 +15,6 @@
 */
 package org.boozallen.plugins.jte.init.primitives
 
-import org.boozallen.plugins.jte.init.primitives.injectors.PipelineConfigVariableInjector
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TemplateLogger
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBinding.groovy
@@ -15,6 +15,7 @@
 */
 package org.boozallen.plugins.jte.init.primitives
 
+import org.boozallen.plugins.jte.init.primitives.injectors.PipelineConfigVariableInjector
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TemplateLogger
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -41,6 +41,7 @@ abstract class TemplatePrimitive extends GlobalVariable implements Serializable{
     String name
     TemplatePrimitiveNamespace parent
 
+    @SuppressWarnings("UnusedMethodParameter")
     @NonCPS
     Object getValue(@Nonnull CpsScript script, Boolean skipOverloaded = false) throws Exception {
         if(! skipOverloaded){

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -41,10 +41,11 @@ abstract class TemplatePrimitive extends GlobalVariable implements Serializable{
     String name
     TemplatePrimitiveNamespace parent
 
-    @Override
     @NonCPS
-    Object getValue(@Nonnull CpsScript script) throws Exception {
-        isOverloaded()
+    Object getValue(@Nonnull CpsScript script, Boolean skipOverloaded = false) throws Exception {
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return this
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
@@ -16,6 +16,7 @@
 package org.boozallen.plugins.jte.init.primitives
 
 import org.boozallen.plugins.jte.util.JTEException
+import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 /**
  * Stores a collection of TemplatePrimitives
@@ -37,7 +38,7 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object getProperty(String property){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == property }
         if(primitive){
-            return primitive.getValue(null)
+            return primitive.getValue( (CpsScript) null, true)
         }
         throw new JTEException("Primitive ${property} not found in ${name}")
     }
@@ -45,7 +46,7 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object methodMissing(String methodName, Object args){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == methodName }
         if(primitive){
-            return primitive.getValue(null).call(args)
+            return primitive.getValue(null, true).call(args)
         }
         throw new JTEException("Primitive ${methodName} not found in ${name}")
     }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
@@ -16,7 +16,6 @@
 package org.boozallen.plugins.jte.init.primitives
 
 import org.boozallen.plugins.jte.util.JTEException
-import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 /**
  * Stores a collection of TemplatePrimitives
@@ -38,7 +37,7 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object getProperty(String property){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == property }
         if(primitive){
-            return primitive.getValue( (CpsScript) null, true)
+            return primitive.getValue(null, true)
         }
         throw new JTEException("Primitive ${property} not found in ${name}")
     }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
@@ -29,8 +29,10 @@ class Keyword extends TemplatePrimitive{
 
     @Override String getName(){ return name }
     @Override String toString(){ return "Keyword '${name}'" }
-    @Override Object getValue(CpsScript script){
-        isOverloaded()
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return value
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
@@ -29,6 +29,7 @@ class Keyword extends TemplatePrimitive{
 
     @Override String getName(){ return name }
     @Override String toString(){ return "Keyword '${name}'" }
+    @SuppressWarnings("UnusedMethodParameter")
     Object getValue(CpsScript script, Boolean skipOverloaded = false){
         if(! skipOverloaded){
             isOverloaded()

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -44,8 +44,10 @@ class Stage extends TemplatePrimitive{
         return "Stage '${name}'"
     }
 
-    @Override Object getValue(CpsScript script){
-        isOverloaded()
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return getCPSClass().newInstance(name: name, steps: steps)
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -44,6 +44,7 @@ class Stage extends TemplatePrimitive{
         return "Stage '${name}'"
     }
 
+    @SuppressWarnings("UnusedMethodParameter")
     Object getValue(CpsScript script, Boolean skipOverloaded = false){
         if(! skipOverloaded){
             isOverloaded()

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -18,7 +18,9 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.FilePath
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.JTEException
@@ -86,9 +88,11 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
     @Override String getName(){ return name }
     String getLibrary(){ return library }
 
-    @Override
-    Object getValue(CpsScript script){
-        isOverloaded()
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        // if permissive_initialization is true, overloaded is okay
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         Class stepwrapperCPS = getPrimitiveClass()
         def s = stepwrapperCPS.newInstance(
             name: this.name,

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -18,9 +18,7 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.FilePath
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
 import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
 import org.boozallen.plugins.jte.util.JTEException
@@ -88,6 +86,7 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
     @Override String getName(){ return name }
     String getLibrary(){ return library }
 
+    @SuppressWarnings("UnusedMethodParameter")
     Object getValue(CpsScript script, Boolean skipOverloaded = false){
         // if permissive_initialization is true, overloaded is okay
         if(! skipOverloaded){

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
@@ -47,7 +47,7 @@ class StageCPS extends Stage{
             }
             StepWrapper clone = s.first().clone()
             clone.setStageContext(stageContext)
-            clone.getValue().call()
+            clone.getValue(null).call()
         }
     }
 

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -148,9 +148,9 @@ class TemplateBindingSpec extends Specification {
         def run
         WorkflowJob job = TestUtil.createAdHoc(jenkins,
             config: '''
-            libraries{ 
+            libraries{
               maven
-              gradle 
+              gradle
             }
             jte{
               permissive_initialization = true

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -127,6 +127,7 @@ class TemplateBindingSpec extends Specification {
         jenkins.assertBuildStatus(Result.FAILURE, run)
         jenkins.assertLogContains("Failed to set variable 'someStep'", run)
     }
+
     def "Access an overloaded step results in exception"() {
         given:
         StepWrapper step = Spy()
@@ -135,6 +136,39 @@ class TemplateBindingSpec extends Specification {
         then:
         thrown(IllegalStateException) // CpsThread not present. doesn't matter for this test.
         1 * step.isOverloaded()
+    }
+
+    def "Invoking overloaded step via namespace works when permissive_initialization is true"(){
+        given:
+        TestLibraryProvider libProvider = new TestLibraryProvider()
+        libProvider.addStep('maven', 'build', 'void call(){ println "build from maven" }')
+        libProvider.addStep('gradle', 'build', 'void call(){ println "build from gradle" }')
+        libProvider.addGlobally()
+
+        def run
+        WorkflowJob job = TestUtil.createAdHoc(jenkins,
+            config: '''
+            libraries{ 
+              maven
+              gradle 
+            }
+            jte{
+              permissive_initialization = true
+            }
+            ''',
+            template: '''
+            jte.libraries.maven.build()
+            jte.libraries.gradle.build()
+            '''
+        )
+
+        when:
+        run = job.scheduleBuild2(0).get()
+
+        then:
+        jenkins.assertBuildStatus(Result.SUCCESS, run)
+        jenkins.assertLogContains("build from maven", run)
+        jenkins.assertLogContains("build from gradle", run)
     }
 
     /****************************


### PR DESCRIPTION
# PR Details

Each `TemplatePrimitive`'s `getValue()` makes a call to `isOverloaded()` to throw an exception if a user tries to directly access a primitive that has an ambiguous name. This could be the case if `jte.permissive_initialization` is set to `true`. 

Unfortunately, we did not factor this in to the way that `TemplatePrimitiveNamespace`s fetch their primitives when accessed via the long-name notation. 

This PR overloads `getValue(CpsScript script, Boolean skipOverloaded = false)` such that the logic to throw exception on overloaded primitives can be skipped when the primitive is accessed via the namespace. 

## How Has This Been Tested

Unit test added to confirm the use case. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
