### PR TITLE
Chore: Code Cleanup for `StepWrapper`, `StepWrapperCPS`, and `StepWrapperFactory`

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -69,7 +69,7 @@ abstract class TemplatePrimitive extends GlobalVariable implements Serializable{
         if(!overloaded.isEmpty()){
             TemplateLogger logger = TemplateLogger.createDuringRun()
             List<String> msg = [
-                    "Attempted to access an overloaded primitive:  ${getName()}",
+                    "Attempted to access an overloaded primitive: ${getName()}",
                     "Please use fully qualified names to access the primitives.",
                     "options: "
             ]

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
@@ -45,7 +45,8 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object methodMissing(String methodName, Object args){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == methodName }
         if(primitive){
-            return primitive.getValue(null, true).call(args)
+            Object value = primitive.getValue(null, true)
+            return args.size() > 0 ? value.call(args) : value.call()
         }
         throw new JTEException("Primitive ${methodName} not found in ${name}")
     }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -49,7 +49,7 @@ class Stage extends TemplatePrimitive{
         if(! skipOverloaded){
             isOverloaded()
         }
-        return getCPSClass().newInstance(name: name, steps: steps)
+        return getCPSClass().newInstance(parent: this)
     }
 
     private Class getCPSClass(){

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
@@ -28,19 +28,22 @@ import org.boozallen.plugins.jte.util.TemplateLogger
 
 @SuppressWarnings("NoDef")
 @InheritConstructors
-class StageCPS extends Stage{
+class StageCPS implements Serializable{
+
+    private static final long serialVersionUID = 1L
+    Stage parent
 
     @SuppressWarnings("MethodParameterTypeRequired")
     void call(args) {
-        TemplateLogger.createDuringRun().print "[Stage - ${getName()}]"
+        TemplateLogger.createDuringRun().print "[Stage - ${parent.name}]"
         Map stageArgs
         if( args instanceof Object[] && 0 < ((Object[])args).length){
             stageArgs = ((Object[])args)[0]
         } else {
             stageArgs = args as Map
         }
-        StageContext stageContext = new StageContext(name: getName(), args: stageArgs)
-        getSteps().each{ stepName ->
+        StageContext stageContext = new StageContext(name: parent.name, args: stageArgs)
+        parent.steps.each{ stepName ->
             List<StepWrapper> s = this.getStepWrappers(stepName)
             if(s.size() > 1){
                 throw new JTEException("Found more than one step for '${stepName}'")

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -20,7 +20,6 @@ import org.boozallen.plugins.jte.init.governance.libs.TestLibraryProvider
 import org.boozallen.plugins.jte.init.primitives.injectors.ApplicationEnvironment
 import org.boozallen.plugins.jte.init.primitives.injectors.Keyword
 import org.boozallen.plugins.jte.init.primitives.injectors.Stage
-import org.boozallen.plugins.jte.init.primitives.injectors.StepWrapper
 import org.boozallen.plugins.jte.util.TestUtil
 import org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService
 import org.jenkinsci.plugins.workflow.job.WorkflowJob

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -131,12 +131,23 @@ class TemplateBindingSpec extends Specification {
 
     def "Access an overloaded step results in exception"() {
         given:
-        StepWrapper step = Spy()
+        TestLibraryProvider libProvider = new TestLibraryProvider()
+        libProvider.addStep('maven', 'build', 'void call(){}')
+        libProvider.addStep('gradle', 'build', 'void call(){}')
+        libProvider.addGlobally()
+
+        def run
+        WorkflowJob job = TestUtil.createAdHoc(jenkins,
+            config: "libraries{ maven; gradle }; jte{ permissive_initialization = true }",
+            template: "build()"
+        )
+
         when:
-        step.getValue(null)
+        run = job.scheduleBuild2(0).get()
+
         then:
-        thrown(IllegalStateException) // CpsThread not present. doesn't matter for this test.
-        1 * step.isOverloaded()
+        jenkins.assertBuildStatus(Result.FAILURE, run)
+        jenkins.assertLogContains("Attempted to access an overloaded primitive: build", run)
     }
 
     def "Invoking overloaded step via namespace works when permissive_initialization is true"(){


### PR DESCRIPTION
# PR Details

Cleaning up a lot of .... suboptimal... code in `StepWrapperFactory`, `StepWrapper`, `StepWrapperCPS`, and `StageCPS`

## Description

1. There was no reason for `StepWrapperCPS` to extend `StepWrapper`. Simplified by giving `StepWrapperCPS` a reference to its parent `StepWrapper`
2. Added `AutoClone` transformation to `StepWrapper` rather than implement the `Cloneable` interface by hand. 
3. `StepWrapperCPS` having a `call` method was an artifact from when we stored `TemplatePrimitive`s in the `TemplateBinding`. Not needed anymore.  Therefore, the code reuse via `invoke` was no longer needed so I deleted and moved code into `methodMissing`. 
4. Simplified `StepWrapperFactory`'s `prepareScript` method signature and re-ordered builder methods up to the top of the file to increase class readability
5. After updating `StepWrapperCPS` to not extend `StepWrapper`, realized same applies to `StageCPS` 

## How Has This Been Tested

All the unit tests still pass. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
