### PR TITLE
Show and hide timestamps in job output

### DIFF
--- a/src/main/resources/org/boozallen/plugins/jte/util/TemplateLogger/Annotator/script.js
+++ b/src/main/resources/org/boozallen/plugins/jte/util/TemplateLogger/Annotator/script.js
@@ -60,6 +60,11 @@ function jteHide(link){
     var id = link.parentNode.getAttribute("jte-id");
     document.querySelectorAll(`span[jte-id='${id}'][first-line='false']`).forEach( (element) => {
         element.style.display = 'none';
+
+        previous = element.previousSibling;
+        if(previous != null && previous.getAttribute("class").includes("timestamp")) {
+            previous.style.display = 'none';
+        }
     });
 }
 function jteShow(link){
@@ -69,5 +74,10 @@ function jteShow(link){
     var id = link.parentNode.getAttribute("jte-id");
     document.querySelectorAll(`span[jte-id='${id}'][first-line='false']`).forEach( (element) => {
         element.style.display = 'inline';
+
+        previous = element.previousSibling;
+        if(previous != null && previous.getAttribute("class").includes("timestamp")) {
+            previous.style.display = 'inline';
+        }
     });
 }

--- a/src/main/resources/org/boozallen/plugins/jte/util/TemplateLogger/Annotator/script.js
+++ b/src/main/resources/org/boozallen/plugins/jte/util/TemplateLogger/Annotator/script.js
@@ -1,8 +1,8 @@
 (function() {
 
 function onLoad(){
-    process() 
-    
+    process()
+
     // Callback function to execute when mutations are observed
     var callback = function(mutationsList, observer) {
         for(var mutation of mutationsList) {
@@ -56,7 +56,7 @@ function jteCollapse(link){
 function jteHide(link){
     link.setAttribute("isHidden",'true');
     link.textContent = "(show)";
-    link.style.visibility = "visible"; 
+    link.style.visibility = "visible";
     var id = link.parentNode.getAttribute("jte-id");
     document.querySelectorAll(`span[jte-id='${id}'][first-line='false']`).forEach( (element) => {
         element.style.display = 'none';
@@ -70,7 +70,7 @@ function jteHide(link){
 function jteShow(link){
     link.setAttribute("isHidden",'false');
     link.textContent = "(hide)";
-    link.style.visibility = ""; 
+    link.style.visibility = "";
     var id = link.parentNode.getAttribute("jte-id");
     document.querySelectorAll(`span[jte-id='${id}'][first-line='false']`).forEach( (element) => {
         element.style.display = 'inline';


### PR DESCRIPTION
# PR Details

When [timestamper](https://plugins.jenkins.io/timestamper/) plugin is enabled, also show and hide timestamps in job output when pressing _show_ and _hide_ links instead of just getting a series of timestamps in a row when the content is collapsed.

Example of incorrect behaviour:
<img width="1301" alt="Screenshot" src="https://user-images.githubusercontent.com/994447/118305375-c756e700-b4df-11eb-9923-3b378366dc81.png">


## Description

This Javascript change hooks into the toggle code and when toggling, if a previous sibling HTML element exists with the `timestamp` CSS class, toggles it along with the JTE output.

Also fixes some whitespace in the file.


## How Has This Been Tested

Change was tested by changing the JS code directly in a running Jenkins instance

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
