### PR TITLE
Archive generated pipeline upon request

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineDecorator.groovy
@@ -175,6 +175,7 @@ class PipelineDecorator extends InvisibleAction implements Serializable{
         Boolean allow_scm_jenkinsfile = true
         Boolean permissive_initialization = false
         Boolean reverse_library_resolution = false
+        Boolean archive_generated_pipeline = false
 
         static LinkedHashMap getSchema(){
             return [
@@ -183,7 +184,8 @@ class PipelineDecorator extends InvisibleAction implements Serializable{
                         allow_scm_jenkinsfile: Boolean,
                         pipeline_template: String,
                         permissive_initialization: Boolean,
-                        reverse_library_resolution: Boolean
+                        reverse_library_resolution: Boolean,
+                        archive_generated_pipeline: Boolean
                     ]
                 ]
             ]


### PR DESCRIPTION
# PR Details

This PR is being submitted to introduce a new function that gives developers the ability to archive a generated pipeline when `jte.archive_generated_pipeline` is set to true.  If the archival of the generated pipeline fails, the fallback method is to log the generated pipeline to the console.

The justification for this PR is to provide developers a stop-gap in the event they need to release an emergency fix to production and JTE fails post-initialization, preventing them from moving forward with the aforementioned fix.  Developers can then apply the generated pipeline to a newly created job, modify the logic to resolve issues observed with the generated JTE pipeline, and get their changes over the finish line.

## Description

A new property - archive_generated_pipeline - will be added to `PipelineDecorator.JteWrapper` and set to false by default. If developers wish to archive the pipeline generated by JTE, then they can set it to true. The `TemplateFlowDefinition` will need to be adjusted to delegate the archiving process to `hudson.tasks.ArtifactArchiver` in conjunction with `hudson.FilePath` to interact with the file system.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
These changes will be tested by adjusting the `AdHocTemplateFlowDefinition` to incorporate the verification of the archiving process. At least one pipeline will need to be created that utilizes all of JTE's pipeline and library constructors (i.e. hooks) and validate that the archived Jenkinsfile actually contains the pipeline injected with all libraries and respective hooks.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The testing environment includes running all the Gradle tests in a Docker container, as well as manual end-to-end testing to ensure UX is acceptable.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
