### PR TITLE
fix docs home page css

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -17,6 +17,8 @@
   display: grid;
   grid-gap: 1rem;
   margin: 0 auto;
+  margin-left: 20%;
+  margin-right: 20%;
   max-width: 1000px;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+  hide:
+  - navigation
+  - toc
+---
+ 
 # Jenkins Templating Engine
 
 Welcome! :wave:


### PR DESCRIPTION
Remove that floating **Home** index on the left-hand side of the home page. 

![image](https://user-images.githubusercontent.com/22510821/137015995-df35df0e-5a48-488b-9872-89e7098ed8df.png)
