### PR TITLE
mkdocs-material to 7.3.6 and add code block titles

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:7.3.3
+FROM squidfunk/mkdocs-material:7.3.6
 RUN pip install \
     mkdocs-gen-files \
     mkdocs-exclude \

--- a/docs/concepts/advanced/overloading-steps.md
+++ b/docs/concepts/advanced/overloading-steps.md
@@ -13,7 +13,7 @@ Instead, overloaded steps must be accessed using the [Pipeline Primitive Namespa
     The following example assumes a `gradle` and `npm` library are available that both contribute a `build()` step.
 
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         jte{
           permissive_initialization = true // pipeline will fail if not set
         }
@@ -23,7 +23,7 @@ Instead, overloaded steps must be accessed using the [Pipeline Primitive Namespa
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         // build() <-- would fail because step is overloaded
         jte.libraries.npm.build() 
         jte.libraries.gradle.build()
@@ -52,7 +52,7 @@ To invoke the original Jenkins Pipeline DSL Step, use the [`steps` Global Variab
     The following example shows how to override the default `node` step to augment its functionality.
 
     === "`node.groovy`"
-        ```groovy
+        ``` groovy title="node.groovy"
         // support the original node interface
         void call(String label = null, Closure body){
             if(label){
@@ -70,7 +70,7 @@ To invoke the original Jenkins Pipeline DSL Step, use the [`steps` Global Variab
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         // assume the Pipeline Configuration loaded the library contributing node.groovy
         node{ println "hi" }
         node("my-label"){ println "hi" }

--- a/docs/concepts/advanced/pipeline-initialization.md
+++ b/docs/concepts/advanced/pipeline-initialization.md
@@ -60,11 +60,11 @@ This compiled Pipeline is then executed **just like any other Jenkinsfile**.
     What follows is an example to understand the transformation that takes place.
 
     === "Provided Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         build()
         ```
     === "Compiled Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         try{
           // code that invokes @Validation annotated methods in steps
           // code that invokes @Init annotated methods in steps 

--- a/docs/concepts/framework-overview/bottom-up.md
+++ b/docs/concepts/framework-overview/bottom-up.md
@@ -14,7 +14,7 @@ Imagine that there are **three** applications that each need a pipeline to autom
 Click through the tabs below to see a pipeline for a Gradle application, a Maven application, and an NPM application.
 
 === "Gradle"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     // a basic Gradle pipeline
     stage("Unit Test"){
       node{
@@ -28,7 +28,7 @@ Click through the tabs below to see a pipeline for a Gradle application, a Maven
     }
     ```
 === "Maven"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     // a basic Maven pipeline
     stage("Unit Test"){
       node{
@@ -42,7 +42,7 @@ Click through the tabs below to see a pipeline for a Gradle application, a Maven
     }
     ```
 === "NPM"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     // a basic NPM pipeline
     stage("Unit Test"){
       node{
@@ -116,8 +116,7 @@ The entire philosophy behind the Jenkins Template Engine stems from the concept 
 
 What if it was possible to translate the three separate pipelines above into the following Pipeline Template:
 
-```groovy
-// file: Jenkinsfile
+``` groovy  title="Jenkinsfile"
 unit_test()
 build()
 ```
@@ -131,8 +130,7 @@ Next, you'll need to define your implementations of the `unit_test()` and `build
 Implement the `unit_test()` and `build()` steps by refactoring the original pipelines above.
 
 === "Gradle: `unit_test`"
-    ```groovy
-    // file: gradle/steps/unit_test.groovy
+    ``` groovy title="gradle/steps/unit_test.groovy"
     void call(){
       stage("Unit Test"){
         node{
@@ -142,8 +140,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
     }
     ```
 === "Gradle: `build`"
-    ```groovy
-    // file: gradle/steps/build.groovy
+    ``` groovy title="gradle/steps/build.groovy"
     void call(){
       stage("Build"){
         node{
@@ -154,8 +151,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
     ```
 <br>
 === "Maven: `unit_test`"
-    ```groovy
-    // file: maven/steps/unit_test.groovy
+    ``` groovy title="maven/steps/unit_test.groovy"
     void call(){
       stage("Unit Test"){
         node{
@@ -165,8 +161,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
     }
     ```
 === "Maven: `build`"
-    ```groovy
-    // file: maven/steps/build.groovy
+    ``` groovy title="maven/steps/build.groovy"
     void call(){
       stage("Build"){
         node{
@@ -177,8 +172,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
     ```
 <br>
 === "NPM: `unit_test`"
-    ```groovy
-    // file: npm/steps/unit_test.groovy
+    ``` groovy title="npm/steps/unit_test.groovy"
     void call(){
       stage("Unit Test"){
         node{
@@ -188,8 +182,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
     }
     ```
 === "NPM: `build`"
-    ```groovy
-    // file: npm/steps/build.groovy
+    ``` groovy title="npm/steps/build.groovy"
     void call(){
       stage("Build"){
         node{
@@ -210,7 +203,7 @@ Implement the `unit_test()` and `build()` steps by refactoring the original pipe
 
 If you go back and look at the comments indicating the files those steps are placed in, you'll notice the following file structure:
 
-```text
+``` text
 .
 ├── gradle
 │   └── steps
@@ -246,8 +239,7 @@ The Pipeline Configuration uses a groovy-based configuration language to ensure 
 
 For example, here's a Pipeline Configuration that specifies the `npm` library should be loaded.
 
-```groovy
-// file: pipeline_config.groovy
+``` groovy title="pipeline_config.groovy"
 libraries{
   npm
 }

--- a/docs/concepts/library-development/library-classes.md
+++ b/docs/concepts/library-development/library-classes.md
@@ -16,7 +16,7 @@ Library classes should implement the `Serializable` interface whenever possible.
 For example, a `Utility` class coming from an `example` library:
 
 <!-- markdownlint-disable code-block-style-->
-```groovy
+``` groovy title="example.groovy"
 package example
 class Utility implements Serializable {}
 ```
@@ -42,7 +42,7 @@ Library classes can not resolve Jenkins pipeline DSL functions such as `sh` or `
 For example, to use the `echo` pipeline step one could do the following:
 
 === "Utility Class"
-    ```groovy
+    ``` groovy title="example.groovy"
     package example
 
     class Utility implements Serializable{
@@ -53,7 +53,7 @@ For example, to use the `echo` pipeline step one could do the following:
     ```
   
 === "Library Step"  
-    ```groovy
+    ``` groovy title="echo_example.groovy"
     import example.Utility
 
     void call(){
@@ -69,7 +69,7 @@ Unlike with library steps, the `config` and `pipelineConfig` variables aren't au
 To access these variables, they can be passed to the class through constructor or method parameters.
 
 === "Utility Class"
-    ```groovy
+    ``` groovy title="example.groovy"
     package example
 
     class Utility implements Serializable{
@@ -84,7 +84,7 @@ To access these variables, they can be passed to the class through constructor o
     }
     ```
 === "Library Step"
-    ```groovy
+    ``` groovy title="get_config.groovy"
     import example.Utility
 
     void call(){

--- a/docs/concepts/library-development/library-configuration-file.md
+++ b/docs/concepts/library-development/library-configuration-file.md
@@ -11,13 +11,13 @@ Currently, the library configuration file is only used to validate library confi
 
 ## Advanced Library Validations
 
-For library parameter validations that more complex than what can be accomplished through the library configuration functionality, library developers can alternatively create a step annotated with the [`@Validate` Lifecycle Hook](lifecycle-hooks.md).
+For library parameter validations that are more complex than what can be accomplished through the library configuration functionality, library developers can alternatively create a step annotated with the [`@Validate` Lifecycle Hook](lifecycle-hooks.md).
 
 Methods within steps annotated with `@Validate` will execute before the Pipeline Template.
 
 For example, if a library wanted to validate a more complex use case such as ensuring a library parameter named `threshold` was greater than or equal to zero but less than or equal to 100 the following could be implemented:
 
-```groovy
+``` groovy title="threshold_check.groovy"
 @Validate [1]
 void call(context){ [2]
   if(config.threshold < 0 || config.threshold > 100){ [3]

--- a/docs/concepts/library-development/library-resources.md
+++ b/docs/concepts/library-development/library-resources.md
@@ -19,8 +19,8 @@ Within a [Library Step](./library-steps.md), the `resource(String relativePath)`
         │       └── data.yaml
         └── library_config.groovy
         ```
-    === "step.groovy"
-        ```groovy
+    === "Library Step"
+        ``` groovy title="step.groovy"
         void call(){
           String script = resource("doSomething.sh")
           def data = readYaml text: resource("nested/data.yaml")

--- a/docs/concepts/library-development/library-steps.md
+++ b/docs/concepts/library-development/library-steps.md
@@ -15,7 +15,7 @@ This can be modified using [Step Aliasing](./step-aliasing.md).
 
 Most steps should implement the `call` method.
 
-```groovy
+``` groovy title="library_step.groovy"
 void call(){}
 ```
 
@@ -51,14 +51,14 @@ All Library Steps are autowired with several variables:
 Library Steps can accept method parameters just like any other method.
 
 !!! example "Library Step Method Parameters"
-    === "printMessage.groovy"
-        ```groovy
+    === "Library Step"
+        ``` groovy title="printMessage.groovy"
         void call(String message){
           println "here's your message: ${message}"
         }
         ```
     === "Step Invocation"
-        ```groovy
+        ``` groovy
         printMessage("hello, world!")
         ```
 
@@ -84,7 +84,7 @@ Frequently, teams will create a `deploy_to` step that accepts an [Application En
 !!! example "Deployment Steps"
     The following Pipeline Template, Pipeline Configuration, and Deployment step demonstrate a safe use of a library step accepting a method parameter.
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         unit_test()
         build()
         deploy_to dev
@@ -92,7 +92,7 @@ Frequently, teams will create a `deploy_to` step that accepts an [Application En
         deploy_to prod
         ```
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         libraries{
           npm     // contributes unit_test, build
           cypress // contributes integration_test
@@ -108,8 +108,7 @@ Frequently, teams will create a `deploy_to` step that accepts an [Application En
         }
         ```
     === "Deployment Step"
-        ```groovy
-        // ansible/steps/deploy_to.groovy
+        ``` groovy title="ansible/steps/deploy_to.groovy"
         void call(app_env){
           println "deploying to the ip: ${app_env.ip}"
         }

--- a/docs/concepts/library-development/library-structure.md
+++ b/docs/concepts/library-development/library-structure.md
@@ -15,7 +15,7 @@ The name of the directory is the library identifier used within the Pipeline Con
 
 ## Example Library Structure
 
-```text
+``` text
 exampleLibraryName [1]
 ├── steps [2]
 │   └── step1.groovy [3]

--- a/docs/concepts/library-development/lifecycle-hooks.md
+++ b/docs/concepts/library-development/lifecycle-hooks.md
@@ -42,7 +42,7 @@ While executing, the code within the `Closure` parameter will be able to resolve
 
 Example Syntax:
 
-```groovy
+``` groovy title="library_step.groovy"
 @BeforeStep({ hookContext.step.equals("build") })
 void call(){
     // execute something right before the Library Step called build is executed.

--- a/docs/concepts/library-development/multi-method-steps.md
+++ b/docs/concepts/library-development/multi-method-steps.md
@@ -13,7 +13,7 @@ The methods on the step can then represent different actions the utility can tak
 
 !!! example "Utility Step Example: Git"
     === "Git Utility Step"
-        ```groovy
+        ``` groovy title="git.groovy"
         void add(String files){
           sh "git add ${files}"
         }
@@ -27,7 +27,7 @@ The methods on the step can then represent different actions the utility can tak
         }
         ```
     === "Usage"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         node{
           checkout scm
           writeFile file: 'test.txt', text: 'hello, world'
@@ -45,7 +45,7 @@ Expressive DSLs can be created when coupling multi-method steps with Groovy's [C
     Command Chains could be used to improve upon the previous example.
 
     === "Without Command Chains"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         node{
           checkout scm
           writeFile file: 'test.txt', text: 'hello, world'
@@ -55,7 +55,7 @@ Expressive DSLs can be created when coupling multi-method steps with Groovy's [C
         }
         ```
     === "**With** Command Chains"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         node{
           checkout scm
           writeFile file: 'test.txt', text: 'hello, world'

--- a/docs/concepts/library-development/parameterizing-libraries.md
+++ b/docs/concepts/library-development/parameterizing-libraries.md
@@ -8,7 +8,7 @@ To achieve this level of reusability, it's best to externalize hard coded values
 
 When specifying a library to be loaded, users can pass arbitrary configurations to the library:
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 libraries{
   example{ [1]
     someField = "my value" [2]

--- a/docs/concepts/library-development/step-aliasing.md
+++ b/docs/concepts/library-development/step-aliasing.md
@@ -16,7 +16,7 @@ Static step aliases are static lists of strings to cast the step to at runtime.
 
 `@StepAlias` can take a `String` parameter to change the name of the step at runtime.
 
-```groovy
+``` groovy title="generic.groovy"
 @StepAlias("build") [1]
 void call(){
     println "running as build!"
@@ -29,7 +29,7 @@ void call(){
 
 `@StepAlias` can also accept an array of Strings to alias the step to multiple names.
 
-```groovy
+``` groovy title="generic.groovy"
 @StepAlias(["build", "unit_test"]) [1]
 void call(){
     println "running as either build or unit_test!"
@@ -45,7 +45,7 @@ This can be accomplished by providing a `dynamic` parameter that should be a `Cl
 
 For example, if a library called `alias` had a step called `generic.groovy` then an `aliases` library parameter could be created:
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 libraries{
   alias{
     aliases = ["build", "unit_test"] [1]
@@ -57,7 +57,7 @@ libraries{
 
 This `aliases` parameter can then be consumed within the dynamic step alias closure:
 
-```groovy
+``` groovy title="generic.groovy"
 @StepAlias(dynamic = { return config.aliases }) [1]
 void call(){
     println "running as either build or unit_test!"
@@ -72,7 +72,7 @@ By default, when `@StepAlias` is present in a step file, a step with the origina
 
 This behavior can be overridden via the `keepOriginal` annotation parameter.
 
-```groovy
+``` groovy title="generic.groovy"
 @StepAlias(value = "build", keepOriginal = true) [1]
 void call(){
     println "running as either build() or generic()"

--- a/docs/concepts/pipeline-configuration/configuration-dsl.md
+++ b/docs/concepts/pipeline-configuration/configuration-dsl.md
@@ -25,11 +25,11 @@ The Pipeline Configuration syntax is a nested builder language that relies on Bl
 Properties of the Pipeline Configuration are set using Groovy's [Variable Assignment](https://groovy-lang.org/semantics.html) syntax.
 
 === "Pipeline Configuration DSL"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     foo = "bar"
     ```
 === "Resulting `pipelineConfig`"
-    ```groovy
+    ``` groovy
     assert pipelineConfig == [ foo: "bar" ]
     ```
 
@@ -39,12 +39,12 @@ Properties of the Pipeline Configuration are set using Groovy's [Variable Assign
     Take the following example: 
 
     === "Pipeline Configuration DSL"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         x = "x" 
         String y = "y"
         ```
     === "Resulting `pipelineConfig`"
-        ```groovy
+        ``` groovy
         assert pipelineConfig == [ x: "x" ]
         ```
 
@@ -55,14 +55,14 @@ Properties of the Pipeline Configuration are set using Groovy's [Variable Assign
 The Pipeline Configuration DSL supports nested properties using Blocks.
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     a{
       x = 1,
       y = 2
     }
     ```
 === "Resulting `pipelineConfig`"
-    ```groovy
+    ``` groovy
     assert pipelineConfig == [
       a: [
         x: 1
@@ -76,7 +76,7 @@ The Pipeline Configuration DSL supports nested properties using Blocks.
 A special case is empty blocks and unset properties. Both situations result in an empty map being set in the Pipeline Configuration.
 
 === "Pipeline Config"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     a{
       x = 1
       y{}
@@ -84,7 +84,7 @@ A special case is empty blocks and unset properties. Both situations result in a
     }
     ```
 === "Resulting `pipelineConfig`"
-    ```groovy
+    ``` groovy
     assert pipelineConfig == [
       a: [
         x: 1,
@@ -101,7 +101,7 @@ To support [Pipeline Governance](../pipeline-governance/overview.md), the Pipeli
 These annotations are called `@override` and `@merge` and both can be placed on a block and property.
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     @merge a{
       x = 1
       @override y = 2

--- a/docs/concepts/pipeline-primitives/application-environments.md
+++ b/docs/concepts/pipeline-primitives/application-environments.md
@@ -10,7 +10,7 @@ Within the Application Environments block, environments are defined through nest
 
 For example, the following code block would create `dev` and `test` variables, each referencing an Application Environment object. These variables can be resolved within the Pipeline Template or Library Steps.
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 application_environments{
   dev
   test
@@ -25,7 +25,7 @@ If not declared, these fields will default to the Application Environment key.
 
 For example:
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 application_environments{
   dev
   test{
@@ -56,7 +56,7 @@ The order Application Environments are defined within the Pipeline Configuration
 
 For example, defining the following Application Environments
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 application_environments{
   dev
   test
@@ -83,7 +83,7 @@ These custom fields can be used to capture characteristics about the Application
 
 For example, if there were IP addresses that the pipeline needed to access during execution:
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 application_environments{
   dev{
     ip_addresses = [ "1.2.3.4", "1.2.3.5" ]
@@ -101,7 +101,7 @@ This would add an `ip_addresses` property to the `dev` and `prod` objects while 
 
 A common pattern is to use Application Environments in conjunction with steps that perform automated deployments. If a library were to contribute a `deploy_to` step that accepted an Application Environment as an input parameter, then a Pipeline Template could be created that leverages these variables.
 
-```groovy
+``` groovy title="Jenkinsfile"
 do_some_tests()
 deploy_to dev
 deploy_to prod
@@ -109,8 +109,7 @@ deploy_to prod
 
 A contrived example of a Library Step that follows this pattern is below.
 
-```groovy
-// within deploy_to.groovy
+``` groovy title="deploy_to.groovy"
 void call(app_env){
   // use the default long_name property to dynamically name the stage
   stage("Deploy to ${app_env.long_name}"){

--- a/docs/concepts/pipeline-primitives/keywords.md
+++ b/docs/concepts/pipeline-primitives/keywords.md
@@ -8,7 +8,7 @@ Keywords are defined via the `keywords{}` block in the Pipeline Configuration.
 
 For example,
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 keywords{
   foo = "bar" 
 }
@@ -22,7 +22,7 @@ would then result in a `foo` variable with the value `"bar"`.
 
 Keywords can be used to define a `globals` variable accessible from the Pipeline Template and Library Steps.
 
-```groovy
+``` groovy title="pipeline_config.groovy"
 keywords{
   globals{
     one = 1
@@ -36,14 +36,14 @@ keywords{
 Keywords can be used to define regular expressions corresponding to common branch names for use from the Pipeline Template to keep the template easy to read.  
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     keywords{
       main = ~/^[mM]a(in|ster)$/
       develop = ~/^[Dd]evelop(ment|er|)$/
     }
     ```
 === "Pipeline Template"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     on_pull_request to: develop, {
       /*
         execute on a PR to branches matching the regular expression

--- a/docs/concepts/pipeline-primitives/primitive-namespace.md
+++ b/docs/concepts/pipeline-primitives/primitive-namespace.md
@@ -10,13 +10,13 @@ If libraries were loaded, the `jte` variable will have a `libraries` property th
 
 !!! example "Invoking a Step Using The Primitive Namespace"
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         libraries{
           npm // contributes a build() step
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         jte.libraries.npm.build()
         ```
 
@@ -26,13 +26,13 @@ If [Keywords](./keywords.md) were defined, the `jte` variable will have a `keywo
 
 !!! example "Accessing Keywords"
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         keywords{
           foo = "bar"
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         assert jte.keywords.foo == "bar"
         ```
 
@@ -42,7 +42,7 @@ If [Application Environments](./application-environments.md) were defined, the `
 
 !!! example "Accessing Application Environments"
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         application_environments{
           dev{
             ip = "1.1.1.1"
@@ -53,7 +53,7 @@ If [Application Environments](./application-environments.md) were defined, the `
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         assert jte.application_environments.dev.ip == "1.1.1.1"
         assert jte.application_environments.prod.ip == "2.2.2.2"
         ```
@@ -64,7 +64,7 @@ If [Stages](./stages.md) were defined, the `jte` variable will have an `stages` 
 
 !!! example "Accessing Application Environments"
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         libraries{
           npm // contributes unit_test, build
         }
@@ -76,6 +76,6 @@ If [Stages](./stages.md) were defined, the `jte` variable will have an `stages` 
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         jte.stages.continuous_integration()
         ```

--- a/docs/concepts/pipeline-primitives/stages.md
+++ b/docs/concepts/pipeline-primitives/stages.md
@@ -20,7 +20,7 @@ The `stageContext` variable allows a step to determine if it's being executed as
 Assume a library called `demo` is available within a configured [Library Source](../library-development/library-source.md).
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     stages{
       continuous_integration{
         unit_test
@@ -31,13 +31,12 @@ Assume a library called `demo` is available within a configured [Library Source]
     }
     ```
 === "Pipeline Template"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     continuous_integration param1: "foo", param2: "bar"
     unit_test()
     ```
-=== "unit_test.groovy"
-    ```groovy
-    // demo/steps/unit_test.groovy
+=== "Library Step"
+    ``` groovy title="demo/steps/unit_test.groovy"
     void call(){
       println "stage name = ${stepContext.name}"
       println "param1 = ${stageContext.args.param1}"
@@ -47,7 +46,7 @@ Assume a library called `demo` is available within a configured [Library Source]
 
 The console log from this pipeline would look similar to:
 
-```text
+``` text
 ...
 stage name = continuous_integration
 param1 = foo
@@ -65,7 +64,7 @@ param2 = null
 A common example would be to create a continuous integration stage to keep templates DRY.
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     ...
     stages{
       continuous_integration{
@@ -77,7 +76,7 @@ A common example would be to create a continuous integration stage to keep templ
     }
     ```
 === "Pipeline Template"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     on_pull_request to: develop, {
       continuous_integration()
     }

--- a/docs/concepts/pipeline-primitives/steps.md
+++ b/docs/concepts/pipeline-primitives/steps.md
@@ -25,19 +25,19 @@ To define Placeholder Steps, use the `template_methods{}` block.
 
     In case that's not true, the `template_methods{}` block has been configured to substitute Placeholder Steps to avoid an exception being thrown. 
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         unit_test()
         build()
         ```
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         template_methods{
           unit_test
           build
         }
         ```
     === "Build Log"
-        ```text
+        ``` text
         [Pipeline] Start of Pipeline
         [JTE][Step - null/unit_test.call()]
         [Pipeline] echo

--- a/docs/concepts/pipeline-templates/declarative-syntax.md
+++ b/docs/concepts/pipeline-templates/declarative-syntax.md
@@ -11,7 +11,7 @@ With JTE, pipeline authors can create Pipeline Templates that look like a custom
 Take the following Pipeline Template and Pipeline Configuration for example:
 
 === "Pipeline Template"
-    ```groovy
+    ``` groovy title="Jenkinsfile"
     on_pull_request to: develop, {
       continuous_integration()
     }
@@ -29,7 +29,7 @@ Take the following Pipeline Template and Pipeline Configuration for example:
     }
     ```
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     libraries{
       git       // supplies on_pull_request, on_merge
       docker    // supplies build
@@ -79,7 +79,7 @@ The way to bypass this in Declarative Syntax to invoke the Library Step is to in
 !!! tip "Declarative Step Resolution Example"
     === "Declarative Pipeline Syntax"
         Assume a `sh` Library Step has been loaded.
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         pipeline{
           agent any
           stages{

--- a/docs/contributing/developer/building.md
+++ b/docs/contributing/developer/building.md
@@ -2,7 +2,7 @@
 
 To build the JPI, run:
 
-```bash
+``` bash
 just jpi
 ```
 

--- a/docs/contributing/developer/linting.md
+++ b/docs/contributing/developer/linting.md
@@ -5,7 +5,7 @@ The CodeNarc rule sets for `src/main` and `src/test` can be found in `config/cod
 
 To execute linting, run:
 
-```bash
+``` bash
 just lint-code
 ```
 

--- a/docs/contributing/developer/local-jenkins.md
+++ b/docs/contributing/developer/local-jenkins.md
@@ -2,7 +2,7 @@
 
 It's often helpful to run Jenkins in a container locally to test various scenarios with JTE during development.
 
-```bash
+``` bash
 just run 
 ```
 
@@ -10,13 +10,13 @@ With the default settings, this will expose jenkins on [http://localhost:8080](h
 
 ## Change the container name
 
-```bash
+``` bash
 just --set container someName run
 ```
 
 ## Change the port forwarding target
 
-```bash
+``` bash
 just --set port 9000 run
 ```
 
@@ -24,7 +24,7 @@ just --set port 9000 run
 
 Parameters passed to `just run` are sent as flags to the `docker run` command.
 
-```bash
+``` bash
 just run -e SOMEVAR="some var"
 ```
 
@@ -34,7 +34,7 @@ Local directories can be configured as Git SCM Library Sources even if they don'
 
 For example, if `~/local-libraries` is a directory containing a local git repository then to mount it to the container you would run:
 
-```bash
+``` bash
 just run -v ~/local-libraries:/local-libraries 
 ```
 
@@ -44,7 +44,7 @@ You could then configure a Library Source using the file protocol to specify the
 !!! tip 
     When using this technique, changes to the libraries must be committed to be found. In a separate terminal, run:
 
-    ```bash
+    ``` bash
     just watch ~/local-libraries
     ```
 

--- a/docs/contributing/developer/releasing.md
+++ b/docs/contributing/developer/releasing.md
@@ -4,7 +4,7 @@
 
 For example:
 
-```bash
+``` bash
 just release 2.0.4
 ```
 

--- a/docs/contributing/developer/running-tests.md
+++ b/docs/contributing/developer/running-tests.md
@@ -4,7 +4,7 @@ Unit tests for JTE are written using [Spock](https://spockframework.org/spock/do
 
 To run all the tests, run:
 
-```bash
+``` bash
 just test
 ```
 
@@ -14,7 +14,7 @@ The gradle test report is published to `build/reports/tests/test/index.html`
 
 To run tests for a specific Class, `StepWrapperSpec` for example, run:
 
-```bash
+``` bash
 just test '*.StepWrapperSpec'
 ```
 
@@ -26,6 +26,6 @@ Once executed, the JaCoCo coverage report can be found at: `build/reports/jacoco
 
 To disable this, run:
 
-```bash
+``` bash
 just --set coverage false test
 ```

--- a/docs/contributing/docs/markdown-cheatsheet.md
+++ b/docs/contributing/docs/markdown-cheatsheet.md
@@ -2,7 +2,7 @@
 
 ## Headers
 
-```markdown
+``` markdown
 # H1
 ## H2
 ### H3
@@ -24,7 +24,7 @@
 There are 3 primary ways embed a hyperlink.
 
 === "Markdown"
-    ```markdown
+    ``` markdown
     1. you can use an [inline link](https://google.com)
     2. you can use a [link by reference][1]
     3. you can use the [link text itself] as the reference
@@ -50,7 +50,7 @@ There are 3 primary ways embed a hyperlink.
 <!-- markdownlint-restore -->
 
 === "Markdown"
-    ```markdown
+    ``` markdown
     |  column 1  |   column 2  | column 3     |
     | ---------- | :---------: | -----------: |
     | column 1   | column 2    | column 3  is |
@@ -67,7 +67,7 @@ There are 3 primary ways embed a hyperlink.
 ## Inline Code Snippets
 
 === "Markdown"
-    ```markdown
+    ``` markdown
     Inline `code` snippets use `backticks` around them
     ```
 === "Rendered"
@@ -78,8 +78,8 @@ There are 3 primary ways embed a hyperlink.
 code blocks use three backticks and the language name for syntax highlighting:
 
 === "Markdown"
-    `````markdown
-    ```groovy
+    ````` markdown
+    ``` groovy title="filename.groovy"
     def s = [ 1, 2, 3]
     s.each{ item ->
       println item
@@ -87,7 +87,7 @@ code blocks use three backticks and the language name for syntax highlighting:
     ```
     `````
 === "Rendered"
-    ```groovy
+    ``` groovy title="filename.groovy"
     def s = [ 1, 2, 3]
     s.each{ item ->
       println item
@@ -118,7 +118,7 @@ A list of the available emojis can be found at [emojipedia](https://emojipedia.o
 
 [Content Tabs](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/) have been used throughout this page.
 
-```markdown
+``` markdown
 === "Tab Title A"
     some markdown content
 === "Tab Title B"
@@ -133,7 +133,7 @@ A list of the available emojis can be found at [emojipedia](https://emojipedia.o
 ## Footnotes
 
 === "Markdown"
-    ```markdown
+    ``` markdown
     Footnotes[^1] are supported.
     [^1]: some footnote information
     ```

--- a/docs/contributing/fork-based.md
+++ b/docs/contributing/fork-based.md
@@ -14,7 +14,7 @@ After forking the upstream repository, it's helpful to add the upstream reposito
 
 This can be done by running the command:
 
-```bash
+``` bash
 git remote add upstream https://github.com/jenkinsci/templating-engine-plugin.git
 ```
 

--- a/docs/how-to/upgrade-2.0/index.md
+++ b/docs/how-to/upgrade-2.0/index.md
@@ -40,7 +40,7 @@ To address this, JTE has pivoted from the flags `merge=true` & `override=true` t
 These annotations can be placed on individual fields within a block, enabling field-level governance.
 
 === "Pre-2.0"
-    ```groovy
+    ``` groovy
     someBlock{
       merge = true // future configs can add fields to this block
       my_governed_field = "some value"// cannot be modified
@@ -52,7 +52,7 @@ These annotations can be placed on individual fields within a block, enabling fi
     }
     ```
 === "Post-2.0"
-    ```groovy
+    ``` groovy
     @merge someBlock{ // future configs can add fields to this block
       my_governed_field = "some value"
     }
@@ -68,14 +68,14 @@ Previously, there were top level configuration values like `allow_scm_jenkinsfil
 These values are now in the `jte` block in the pipeline_config
 
 === "Pre-2.0"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     allow_scm_jenkinsfile = false
     pipeline_template = "my_template"
     libraries{} // just here to show the relation to the root
     ```
 
 === "Post-2.0"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     jte{
       allow_scm_jenkinsfile = false
       pipeline_template = "my_template"
@@ -91,14 +91,14 @@ Previously, library steps that implemented lifecycle hooks were required to acce
 This parameter was typically called `context` but could be called anything.
 
 === "Pre-2.0"
-    ```groovy
+    ``` groovy
     @AfterStep({ context.step == "build" }) // variable called context
     void call(context){ // hooks required to accept a method parameter
       println "running after the ${context.step} step"
     }
     ```
 === "Post-2.0"
-    ```groovy
+    ``` groovy
     @AfterStep({ hookContext.step == "build"}) // variable called hookContext
     void call(){ // no method parameter required
       println "running after the ${hookContext.step} step" // hookContext variable autowired

--- a/docs/reference/autowired-variables.md
+++ b/docs/reference/autowired-variables.md
@@ -23,15 +23,15 @@ The `pipelineConfig` is accessible from everywhere and allows access to the aggr
 !!! example "Example Usage of `pipelineConfig`"
     An example of accessing the Pipeline Configuration via `pipelineConfig`:
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         keywords{
           foo = "bar"
         }
         random_field = 11
         ```
     === "Pipeline Template"
-        ```groovy
-        println pipelineconfig.keywords.foo
+        ``` groovy title="Jenkinsfile"
+        println pipelineConfig.keywords.foo
         println pipelineConfig.random_field
         ```
 
@@ -51,7 +51,7 @@ This is different from the `pipelineConfig` variable. The `pipelineConfig` varia
     The `jte` would be used in this scenario to invoke the `build()` step from the `gradle` and `npm` libraries. 
     
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         jte{
           permissive_initialization = true
         }
@@ -61,7 +61,7 @@ This is different from the `pipelineConfig` variable. The `pipelineConfig` varia
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         // invoke the gradle build step
         jte.libraries.gradle.build()
         // invoke the npm build step
@@ -98,15 +98,15 @@ The `config` variable represents the library configuration for the library that 
     Assume there's a `gradle` library that contributes a `build()` step.
 
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         libraries{
           gradle{
             version = "6.3"
           }
         }
         ```
-    === "build.groovy"
-        ```groovy
+    === "Library build() Step"
+        ``` groovy title="build.groovy"
         void call(){
           String gradleVersion = config.version
         }
@@ -125,7 +125,7 @@ The `hookContext` variable provides information about the current step to [Lifec
     The following example shows how to use the `hookContext` variable so that a Lifecycle Hook only triggers after the `build()` step from the `gradle` library.
 
     === "Lifecycle Hook Step"
-        ```groovy
+        ``` groovy
         @AfterStep({ hookContext.library == "gradle" && hookContext.step == "build" })
         void call(){
           println "running after the ${hookContext.library}'s ${hookContext.step} step"
@@ -144,7 +144,7 @@ The `stageContext` variable provides information about the current [Stage](../co
 !!! example "Example usage of `stageContext`"
     The following example shows how to modify step behavior based upon Stage context.
     === "Pipeline Configuration"
-        ```groovy
+        ``` groovy title="pipeline_config.groovy"
         libraries{
           npm // contributes unit_test()
           sonarqube // contributes static_code_analysis()
@@ -156,8 +156,8 @@ The `stageContext` variable provides information about the current [Stage](../co
           }
         }
         ```
-    === "NPM: unit_test.groovy"
-        ```groovy
+    === "NPM unit_test() Step"
+        ``` groovy title="unit_test.groovy"
         void call(){
           if(stageContext.name == "ci"){
             println "running as part of the ci Stage"
@@ -177,14 +177,14 @@ The `stepContext` allows step introspection, such as querying the name of the li
 
 !!! example "Example usage of `stepContext`"
     === "Aliased Step"
-        ```groovy
+        ``` groovy title="generic.groovy"
         @StepAlias(["build", "unit_test"])
         void call(){
           println "currently running as ${stepContext.name}"
         }
         ```
     === "Pipeline Template"
-        ```groovy
+        ``` groovy title="Jenkinsfile"
         build() // prints "currently running as build"
         unit_test() // prints "currently running as unit_test"
         ```

--- a/docs/reference/library-configuration-schema.md
+++ b/docs/reference/library-configuration-schema.md
@@ -6,7 +6,7 @@ This page outlines the schema for [Library Configuration Files](../concepts/libr
 
 ### Schema
 
-```groovy
+``` groovy title="library_config.groovy"
 fields{ [1]
   required{} [2]
   optional{} [3]
@@ -47,7 +47,7 @@ The current options for data types to test for are:
 
 !!! example "Type Validation Example"
     === "Library Configuration File"
-        ```groovy
+        ``` groovy title="library_config.groovy"
         fields{
           required{
             parameterA = String [1]
@@ -63,8 +63,8 @@ The current options for data types to test for are:
     1. ensures that `parameterA` was configured and is an instance of a String
     2. ensures that `parameterB` was configured and is an instance of a Number
     3. ensures that `parameterC` was configured and is an instance of a Boolean
-    4. _if_ `parameterD` was configured, ensures it's a String
-    5. _if_ `parameterE` was configured, ensures it's a Boolean
+4._if_`parameterD` was configured, ensures it's a String
+5._if_ `parameterE` was configured, ensures it's a Boolean
 
 #### Enum Validation
 
@@ -72,7 +72,7 @@ The enum validation ensures that a library parameter value is one of the options
 
 !!! example "Enum Validation Example"
     === "Library Configuration File"
-        ```groovy
+        ``` groovy title="library_config.groovy"
         fields{
           required{
             parameterA = [ "a", "b", 11 ] [1]
@@ -87,7 +87,7 @@ Regular expression validation uses Groovy's [match operator](https://docs.groovy
 
 !!! example "Regular Expression Example"
     === "Library Configuration File"
-        ```groovy
+        ``` groovy title="library_config.groovy"
         fields{
           required{
             parameterA = ~/^s.*/ [1]
@@ -103,7 +103,7 @@ Library parameters can be arbitrarily nested within the pipeline configuration.
 For example, the following pipeline configuration would be valid to pass the `example.nestedParameter` parameter to a library named `testing`.
 
 === "Pipeline Configuration"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     libraries{
       testing{
         example{
@@ -113,7 +113,7 @@ For example, the following pipeline configuration would be valid to pass the `ex
     }
     ```
 === "Library Configuration"
-    ```groovy
+    ``` groovy title="library_config.groovy"
     fields{
       required{
         example{

--- a/docs/reference/pipeline-configuration-schema.md
+++ b/docs/reference/pipeline-configuration-schema.md
@@ -18,7 +18,7 @@ The `jte{}` block of the Pipeline Configuration is reserved for fields that chan
 | `reverse_library_resolution` | Determine whether to reverse the order that [Library Sources](../concepts/library-development/library-source.md) are queried for a library. Refer to [Library Resolution](../concepts/pipeline-governance/library-resolution.md) for more information.                                                                             | Boolean | `False` |
 
 !!! example "Example JTE Block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     jte{
       allow_scm_jenkinsfile = False
       permissive_initialization = True
@@ -34,7 +34,7 @@ The `template_methods{}` block is used to define the names of steps to create a 
 Refer to [Placeholder Steps](../concepts/pipeline-primitives/steps.md#placeholder-steps) for more information.
 
 !!! example "Example template_methods block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     template_methods{
       unit_test
       build
@@ -49,7 +49,7 @@ The `libraries{}` block determines which libraries to load. The block names with
 Refer to the [Library Development Overview](../concepts/library-development/overview.md) for more information.
 
 !!! example "Example libraries block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     libraries{
       library_A{
         param1 = "foo"
@@ -65,7 +65,7 @@ Refer to the [Library Development Overview](../concepts/library-development/over
 The `stages{}` block is used to define [Stages](../concepts/pipeline-primitives/stages.md).
 
 !!! example "Example stages block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     stages{
       stage_name{
         step1
@@ -81,7 +81,7 @@ The `stages{}` block is used to define [Stages](../concepts/pipeline-primitives/
 The `application_environments{}` block is used to define [Application Environments](../concepts/pipeline-primitives/application-environments.md).
 
 !!! example "Example application_environments block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     application_environments{
       dev{
         long_name = "Development"
@@ -96,7 +96,7 @@ The `application_environments{}` block is used to define [Application Environmen
 The `keywords{}` block is used to define [Keywords](../concepts/pipeline-primitives/keywords.md).
 
 !!! example "Example keywords block"
-    ```groovy
+    ``` groovy title="pipeline_config.groovy"
     keywords{
       main = ~/^[Mm](ain|aster)$/
       globals{


### PR DESCRIPTION
# PR Details

Updating docs framework version and updating formatting to use new feature.

## Description

Moved [mkdocs-material container](https://hub.docker.com/r/squidfunk/mkdocs-material) version to latest (`7.3.6`) and added code block titles to docs where they made sense.

## How Has This Been Tested

ran `just lint-docs` to confirm no linter issues were introduced, then ran `just server` to test the docs site locally.

## Types of Changes

- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
