### PR TITLE
Set custom path for pipeline configuration file in the source code repository

### DIFF
--- a/docs/concepts/pipeline-configuration/overview.md
+++ b/docs/concepts/pipeline-configuration/overview.md
@@ -35,4 +35,4 @@ Pipeline Configurations can be stored in a couple different locations depending 
 | Job Type             | Pipeline Configuration Location                                                                                                               |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | Pipeline Job         | Either in the Jenkins UI or at the root of a remote source code repository as a file called `pipeline_config.groovy`                          |
-| Multi-Branch Project | At the root of the repository in a file named `pipeline_config.groovy` in the branch job that was created as part of the Multi-Branch Project |
+| Multi-Branch Project | At the root of the repository in a file named `pipeline_config.groovy` (or to any arbitrary path in the repository as configured by `configurationPath`) in the branch job that was created as part of the Multi-Branch Project |

--- a/docs/concepts/pipeline-governance/pipeline-template-selection.md
+++ b/docs/concepts/pipeline-governance/pipeline-template-selection.md
@@ -23,7 +23,7 @@ If not, JTE will follow the flow described throughout the rest of this document.
 
 ### MultiBranch Project Pipeline Jobs
 
-For MultiBranch Project Pipeline Jobs, if the source code repository has a `Jenkinsfile` at the root **and** `jte.allow_scm_jenkinsfile` is set to `True`, then the repository `Jenkinsfile` will be used as the Pipeline Template.
+For MultiBranch Project Pipeline Jobs, if the source code repository has a `Jenkinsfile` at the root (or at any arbitrary path in the repository as configured by `scriptPath`) **and** `jte.allow_scm_jenkinsfile` is set to `True`, then the repository `Jenkinsfile` will be used as the Pipeline Template.
 
 !!! important "Disabling Repository Jenkinsfiles"
     It's important that when trying to enforce a certain set of Pipeline Templates are used that `jte.allow_scm_jenkinsfile` is set to `False`.

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
@@ -20,6 +20,7 @@ import org.boozallen.plugins.jte.init.governance.config.ScmPipelineConfiguration
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationDsl
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
+import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition
@@ -74,7 +75,14 @@ class PipelineConfigurationAggregator {
         } else {
             // get job config if present
             FileSystemWrapper fsw = FileSystemWrapper.createFromJob(flowOwner)
-            String repoConfigFile = fsw.getFileContents(ScmPipelineConfigurationProvider.CONFIG_FILE, "Template Configuration File", false)
+            // enable custom path to config file instead of default pipeline_config.groovy at root
+            String configurationPath
+            if (flowDefinition instanceof MultibranchTemplateFlowDefinition) {
+                configurationPath = flowDefinition.getConfigurationPath()
+            } else {
+                configurationPath = ScmPipelineConfigurationProvider.CONFIG_FILE
+            }
+            String repoConfigFile = fsw.getFileContents(configurationPath, "Template Configuration File", false)
             if (repoConfigFile){
                 try{
                     jobConfig = new PipelineConfigurationDsl(flowOwner).parse(repoConfigFile)

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
@@ -18,6 +18,7 @@ package org.boozallen.plugins.jte.init
 import org.boozallen.plugins.jte.init.governance.GovernanceTier
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
+import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition
@@ -50,7 +51,14 @@ class PipelineTemplateResolver {
             }
         } else {
             FileSystemWrapper fs = FileSystemWrapper.createFromJob(flowOwner)
-            String repoJenkinsfile = fs.getFileContents("Jenkinsfile", "Repository Jenkinsfile", false)
+            // enable custom path to template file instead of default Jenkinsfile at root
+            String templatePath
+            if (flowDefinition instanceof MultibranchTemplateFlowDefinition) {
+                templatePath = flowDefinition.getScriptPath()
+            } else {
+                templatePath = "Jenkinsfile"
+            }
+            String repoJenkinsfile = fs.getFileContents(templatePath, "Repository Jenkinsfile", false)
             if (repoJenkinsfile){
                 if (jteBlockWrapper.allow_scm_jenkinsfile){
                     return repoJenkinsfile

--- a/src/main/groovy/org/boozallen/plugins/jte/job/MultibranchTemplateFlowDefinition.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/MultibranchTemplateFlowDefinition.groovy
@@ -21,11 +21,33 @@ import hudson.model.DescriptorVisibilityFilter
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
+import org.kohsuke.stapler.DataBoundSetter
 
 /**
  * Allows JTE to be used in a MultiBranch Pipeline
  */
 class MultibranchTemplateFlowDefinition extends TemplateFlowDefinition {
+
+    String scriptPath
+    String configurationPath
+
+    @DataBoundSetter
+    void setScriptPath(String scriptPath){
+        this.scriptPath = scriptPath
+    }
+
+    String getScriptPath(){
+        return scriptPath
+    }
+
+    @DataBoundSetter
+    void setConfigurationPath(String configurationPath){
+        this.configurationPath = configurationPath
+    }
+
+    String getConfigurationPath(){
+        return configurationPath
+    }
 
     @Extension
     static class DescriptorImpl extends FlowDefinitionDescriptor {

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory.groovy
@@ -27,6 +27,7 @@ import jenkins.branch.OrganizationFolder
 import jenkins.model.TransientActionFactory
 import jenkins.scm.api.SCMSource
 import jenkins.scm.api.SCMSourceCriteria
+import org.boozallen.plugins.jte.init.governance.config.ScmPipelineConfigurationProvider
 import org.jenkinsci.plugins.workflow.cps.Snippetizer
 import org.jenkinsci.plugins.workflow.multibranch.AbstractWorkflowBranchProjectFactory
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
@@ -40,6 +41,8 @@ import org.kohsuke.stapler.DataBoundSetter
  */
 class TemplateMultiBranchProjectFactory extends MultiBranchProjectFactory.BySCMSourceCriteria {
 
+    String scriptPath
+    String configurationPath
     Boolean filterBranches
 
     // jenkins requires this be here
@@ -48,10 +51,34 @@ class TemplateMultiBranchProjectFactory extends MultiBranchProjectFactory.BySCMS
     TemplateMultiBranchProjectFactory(){}
 
     Object readResolve() {
+        if (this.scriptPath == null) {
+            this.scriptPath = 'Jenkinsfile'
+        }
+        if (this.configurationPath == null) {
+            this.configurationPath = ScmPipelineConfigurationProvider.CONFIG_FILE
+        }
         if (this.filterBranches == null) {
             this.filterBranches = false
         }
         return this
+    }
+
+    @DataBoundSetter
+    void setScriptPath(String scriptPath){
+        this.scriptPath = scriptPath
+    }
+
+    String getScriptPath(){
+        return scriptPath
+    }
+
+    @DataBoundSetter
+    void setConfigurationPath(String configurationPath){
+        this.configurationPath = configurationPath
+    }
+
+    String getConfigurationPath(){
+        return configurationPath
     }
 
     @DataBoundSetter
@@ -72,6 +99,8 @@ class TemplateMultiBranchProjectFactory extends MultiBranchProjectFactory.BySCMS
 
     private AbstractWorkflowBranchProjectFactory newProjectFactory() {
         TemplateBranchProjectFactory factory = new TemplateBranchProjectFactory()
+        factory.setScriptPath(this.scriptPath)
+        factory.setConfigurationPath(this.configurationPath)
         factory.setFilterBranches(this.filterBranches)
         return factory
     }

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/config.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/config.jelly
@@ -16,6 +16,12 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="Pipeline Template Path" field="scriptPath">
+        <f:textbox default="Jenkinsfile"/>
+    </f:entry>
+    <f:entry title="Pipeline Configuration Path" field="configurationPath">
+        <f:textbox default="pipeline_config.groovy"/>
+    </f:entry>
     <f:entry title="${%Exclude branches without a pipeline configuration file}" field="filterBranches">
         <f:checkbox default="false"/>
     </f:entry>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/help-configurationPath.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/help-configurationPath.html
@@ -1,0 +1,3 @@
+<p>
+    A Pipeline Configuration file that will be used when loading this Pipeline.
+</p>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/help-filterBranches.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory/help-filterBranches.html
@@ -1,5 +1,6 @@
 <div>
-    If checked, the Jenkins Templating Engine will exclude branches that do not have a Pipeline Configuration file (pipeline_config.groovy) at the root of the repository.
-    
-    If unchecked, a pipeline will be created for all branches. 
+    If checked, the Jenkins Templating Engine will exclude branches that do not have a Pipeline Configuration file
+    (pipeline_config.groovy) in the repository at the path specified by configurationPath.
+
+    If unchecked, a pipeline will be created for all branches.
 </div>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/config.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/config.jelly
@@ -16,6 +16,12 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="Pipeline Template Path" field="scriptPath">
+        <f:textbox default="Jenkinsfile"/>
+    </f:entry>
+    <f:entry title="Pipeline Configuration Path" field="configurationPath">
+        <f:textbox default="pipeline_config.groovy"/>
+    </f:entry>
     <f:entry title="${%Exclude repository branches without a pipeline configuration file}" field="filterBranches">
         <f:checkbox default="false"/>
     </f:entry>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-configurationPath.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-configurationPath.html
@@ -1,0 +1,3 @@
+<p>
+    A Pipeline Configuration file that will be used when loading this Pipeline.
+</p>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-filterBranches.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-filterBranches.html
@@ -1,5 +1,6 @@
 <div>
-    If checked, the Jenkins Templating Engine will exclude branches that do not have a Pipeline Configuration file (pipeline_config.groovy) at the root of the repository.
-    
-    If unchecked, a pipeline will be created for all branches. 
+    If checked, the Jenkins Templating Engine will exclude branches that do not have a Pipeline Configuration file
+    (pipeline_config.groovy) in the repository at the path specified by configurationPath.
+
+    If unchecked, a pipeline will be created for all branches.
 </div>

--- a/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-scriptPath.html
+++ b/src/main/resources/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory/help-scriptPath.html
@@ -1,0 +1,3 @@
+<p>
+    Relative location within the checkout of your Pipeline script.
+</p>

--- a/src/test/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactorySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactorySpec.groovy
@@ -1,0 +1,105 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+package org.boozallen.plugins.jte.job
+
+import jenkins.branch.BranchSource
+import jenkins.branch.OrganizationFolder
+import jenkins.plugins.git.GitSCMSource
+import jenkins.plugins.git.GitSampleRepoRule
+import jenkins.scm.impl.SingleSCMNavigator
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
+import org.junit.ClassRule
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Shared
+import spock.lang.Specification
+
+class TemplateBranchProjectFactorySpec extends Specification {
+
+    @Shared @ClassRule JenkinsRule jenkins = new JenkinsRule()
+    @Rule GitSampleRepoRule repo = new GitSampleRepoRule()
+
+    String templatePath = 'dir/Jenkinsfile'
+    String configPath = 'dir/pipeline_config.groovy'
+
+    def setup() {
+        String pipelineConfigContents = '''
+        block{
+            custom = 'hello'
+        }
+        '''
+        String pipelineTemplateContents = '''
+        node {
+            stage('Build') {
+                echo "build number: ${env.BUILD_NUMBER}"
+                echo "branch: ${env.BRANCH_NAME}"
+                echo "custom: ${pipelineConfig.block.custom}"
+            }
+        }
+        '''
+        repo.init()
+        repo.write(templatePath, pipelineTemplateContents)
+        repo.write(configPath, pipelineConfigContents)
+        repo.git('add', '*')
+        repo.git('commit', '--message=init')
+    }
+
+    def "Specify custom template and configuration path with TemplateBranchProjectFactory"() {
+        given:
+        WorkflowMultiBranchProject mp = jenkins.createProject(WorkflowMultiBranchProject)
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, repo.toString(), "", "*", "", false)))
+        TemplateBranchProjectFactory factory = new TemplateBranchProjectFactory()
+        factory.setConfigurationPath(configPath)
+        factory.setScriptPath(templatePath)
+        factory.setFilterBranches(true)
+        mp.setProjectFactory(factory)
+
+        when:
+        mp.scheduleBuild2(0).getFuture().get()
+        jenkins.waitUntilNoActivity()
+        WorkflowRun run = mp.getItem('master').getLastBuild()
+
+        then:
+        jenkins.assertBuildStatusSuccess(run)
+        jenkins.assertLogContains('custom: hello', run)
+        jenkins.assertLogContains('branch: master', run)
+        jenkins.assertLogContains('build number: 1', run)
+    }
+
+    def "Specify custom template and configuration path with TemplateMultiBranchProjectFactory"() {
+        given:
+        OrganizationFolder folder = jenkins.createProject(OrganizationFolder)
+        folder.getNavigators().add(new SingleSCMNavigator('repo', [new GitSCMSource(null, repo.toString(), "", "*", "", false)]))
+        TemplateMultiBranchProjectFactory factory = new TemplateMultiBranchProjectFactory()
+        factory.setConfigurationPath(configPath)
+        factory.setScriptPath(templatePath)
+        factory.setFilterBranches(true)
+        folder.getProjectFactories().add(factory)
+
+        when:
+        folder.scheduleBuild2(0).getFuture().get()
+        jenkins.waitUntilNoActivity()
+        WorkflowRun run = folder.getItem('repo').getItem('master').getLastBuild()
+
+        then:
+        jenkins.assertBuildStatusSuccess(run)
+        jenkins.assertLogContains('custom: hello', run)
+        jenkins.assertLogContains('branch: master', run)
+        jenkins.assertLogContains('build number: 1', run)
+    }
+
+}


### PR DESCRIPTION
# PR Details

Enable configuration of custom paths for template and config files when retrieving them from the source code repository for Multibranch projects to address issue https://github.com/jenkinsci/templating-engine-plugin/issues/99

<!--- Provide a general summary of your changes in the Title above -->

## Description

`TemplateBranchProjectFactory` and `TemplateMultiBranchProjectFactory` have been modified to store a new `String configurationPath` (which defaults to `pipeline_config.groovy`) and allows users to specify which path in the repository to fetch the pipeline configuration file from instead of always fetching from root. Also enabled this same selection for the pipeline template file via field `String scriptPath` which defaults to `Jenkinsfile`.

`MultibranchTemplateFlowDefinition` has been updated to account for these fields, and thus the `PipelineConfigurationAggregator` and `PipelineTemplateResolver` classes now have extra behaviour for this definition in case a custom path has been specified.

Documentation, resources been updated and a new unit test added.

<!--- Describe your changes in detail -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `just test` as well as some local testing with `just run`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
