### PR TITLE
Resolve exceptions when loading more than 128 files

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidator.groovy
@@ -95,7 +95,7 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor
         List<String> functionNames = StepDescriptor.all().collect { step ->
             step.getFunctionName()
         }
-        List<String> stepCollisions = primitivesByName.keySet().intersect(functionNames)
+        List<String> stepCollisions = primitivesByName.keySet().intersect(functionNames) as List
         if(!stepCollisions.isEmpty()) {
             List<String> msg = ["Template Primitives are overwriting Jenkins steps with the following names:"]
             stepCollisions.eachWithIndex { step, idx ->

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
@@ -272,9 +272,9 @@ class GlobalCollisionValidatorSpec extends Specification {
         given:
         primitivesByName = [:]
         (0..127).each { i ->
-            String step_name = "step_${i}".toString()
-            DummyPrimitive fake_step = new DummyPrimitive(name: step_name)
-            primitivesByName[step_name] = [ fake_step ]
+            String stepName = "step_${i}"
+            DummyPrimitive fakeStep = new DummyPrimitive(name: stepName)
+            primitivesByName[stepName] = [ fakeStep ]
         }
         when:
         validator.checkForJenkinsStepCollisions(primitivesByName, logger)

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
@@ -30,6 +30,7 @@ import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.WithoutJenkins
 import spock.lang.Ignore
+import spock.lang.Issue
 import spock.lang.Specification
 
 class GlobalCollisionValidatorSpec extends Specification {
@@ -263,6 +264,23 @@ class GlobalCollisionValidatorSpec extends Specification {
         then:
         noExceptionThrown()
         1 * logger.printWarning(_)
+    }
+
+    @Issue("https://github.com/jenkinsci/templating-engine-plugin/issues/256")
+    @WithoutJenkins
+    def "regression: more than 128 steps throws exception"(){
+        given:
+        primitivesByName = [:]
+        (0..127).each { i ->
+            String step_name = "step_${i}".toString()
+            DummyPrimitive fake_step = new DummyPrimitive(name: step_name)
+            primitivesByName[step_name] = [ fake_step ]
+        }
+        when:
+        validator.checkForJenkinsStepCollisions(primitivesByName, logger)
+
+        then:
+        noExceptionThrown()
     }
 
 }


### PR DESCRIPTION
# PR Details

The `GlobalCollisionValidator` would previously throw an exception when more than 128 steps were loaded.
Explicitly casting to a `List` resolves this error. 

fixes #256 

## How Has This Been Tested

Behavior reproduced both via a test and manually in a live Jenkins instance.
The test now passes and the fix has been confirmed against a live Jenkins instance.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
