### PR TITLE
Application Environment ignores user configuration for `name` 

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironment.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironment.groovy
@@ -58,9 +58,20 @@ class ApplicationEnvironment extends TemplatePrimitive implements Serializable{
 
     @Override String getName(){ return name }
 
-    Object getProperty(String name){
-        def meta = ApplicationEnvironment.metaClass.getMetaProperty(name)
-        return meta ? meta.getProperty(this) : config?."${name}"
+    Object getProperty(String property){
+        // first check user-defined configuration
+        if (config.containsKey(property)){
+            return config?."${property}"
+        }
+
+        // then check this object itself
+        def meta = ApplicationEnvironment.metaClass.getMetaProperty(property)
+        if (meta){
+            return meta.getProperty(this)
+        }
+
+        // otherwise return null if property is missing
+        return null
     }
 
     @SuppressWarnings("UnusedMethodParameter")

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentSpec.groovy
@@ -22,6 +22,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -404,6 +405,25 @@ class ApplicationEnvironmentSpec extends Specification {
             ''',
             template: '''
             assert jte.application_environments.dev.custom_field == "banana"
+            '''
+        )
+        expect:
+        jenkins.buildAndAssertSuccess(job)
+    }
+
+    @Issue("https://github.com/jenkinsci/templating-engine-plugin/issues/254")
+    def "ApplicationEnvironment respects name configuration"(){
+        given:
+        WorkflowJob job = TestUtil.createAdHoc(jenkins,
+            config: '''
+            application_environments{
+                dev{
+                    name = "custom"
+                }
+            }
+            ''',
+            template: '''
+            assert dev.name == "custom"
             '''
         )
         expect:


### PR DESCRIPTION
# PR Details

The `ApplicationEnvironment` primitive was previously checking the object prior to checking the user provided definition of the application environment in the pipeline configuration. 

This meant that for certain fields, such as `name`, the value would return unexpected results.

fixes #254 

## Description

Updated the order in which properties on the `ApplicationEnvironment` class are fetched. 
We now first check the pipeline configuration definition and then proceed to the object itself. 
If no property is found, we still return `null`. 

## How Has This Been Tested

Unit tests. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
