### PR TITLE
Refactor FileSystemWrapper

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -144,7 +144,7 @@ finish:
   fi
 
   # re-sync main & delete the previous branch
-  git fetch -a 
+  git fetch --all
   git checkout main
   git merge upstream/main
   git push origin main

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
@@ -22,6 +22,7 @@ import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfiguratio
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
 import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
@@ -74,7 +75,7 @@ class PipelineConfigurationAggregator {
             jobConfig = flowDefinition.getPipelineConfiguration(flowOwner)
         } else {
             // get job config if present
-            FileSystemWrapper fsw = FileSystemWrapper.createFromJob(flowOwner)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(flowOwner)
             // enable custom path to config file instead of default pipeline_config.groovy at root
             String configurationPath
             if (flowDefinition instanceof MultibranchTemplateFlowDefinition) {

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
@@ -20,6 +20,7 @@ import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfiguratio
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
 import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
@@ -50,7 +51,7 @@ class PipelineTemplateResolver {
                 return template
             }
         } else {
-            FileSystemWrapper fs = FileSystemWrapper.createFromJob(flowOwner)
+            FileSystemWrapper fs = FileSystemWrapperFactory.create(flowOwner)
             // enable custom path to template file instead of default Jenkinsfile at root
             String templatePath
             if (flowDefinition instanceof MultibranchTemplateFlowDefinition) {

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProvider.groovy
@@ -22,6 +22,7 @@ import hudson.scm.SCM
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationDsl
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.kohsuke.stapler.DataBoundConstructor
@@ -58,7 +59,7 @@ class ScmPipelineConfigurationProvider extends PipelineConfigurationProvider{
     PipelineConfigurationObject getConfig(FlowExecutionOwner owner){
         PipelineConfigurationObject configObject = null
         if (scm && !(scm instanceof NullSCM)){
-            FileSystemWrapper fsw = FileSystemWrapper.createFromSCM(owner, scm)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(owner, scm)
             String filePath = "${baseDir ? "${baseDir}/" : ""}${CONFIG_FILE}"
             String configFile = fsw.getFileContents(filePath, "Pipeline Configuration File")
             if (configFile){
@@ -77,7 +78,7 @@ class ScmPipelineConfigurationProvider extends PipelineConfigurationProvider{
     String getJenkinsfile(FlowExecutionOwner owner){
         String jenkinsfile = null
         if(scm && !(scm instanceof NullSCM)){
-            FileSystemWrapper fsw = FileSystemWrapper.createFromSCM(owner, scm)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(owner, scm)
             String filePath = "${baseDir ? "${baseDir}/" : ""}Jenkinsfile"
             jenkinsfile = fsw.getFileContents(filePath, "Template")
         }
@@ -88,7 +89,7 @@ class ScmPipelineConfigurationProvider extends PipelineConfigurationProvider{
     String getTemplate(FlowExecutionOwner owner, String template){
         String pipelineTemplate = null
         if(scm && !(scm instanceof NullSCM)){
-            FileSystemWrapper fsw = FileSystemWrapper.createFromSCM(owner, scm)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(owner, scm)
             String filePath = "${baseDir ? "${baseDir}/" : ""}${PIPELINE_TEMPLATE_DIRECTORY}/${template}"
             pipelineTemplate = fsw.getFileContents(filePath, "Pipeline Template")
         }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
@@ -22,6 +22,7 @@ import hudson.scm.SCM
 import jenkins.scm.api.SCMFile
 import jenkins.scm.api.SCMFileSystem
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
@@ -156,10 +157,10 @@ class ScmLibraryProvider extends LibraryProvider{
         return [baseDir, s?.trim()].findAll{ it }.join("/")
     }
 
-    // lol CodeNarc is probably right and we should find a new place for this
+    // TODO: lol CodeNarc is probably right and we should find a new place for this
     @SuppressWarnings('FactoryMethodName')
     SCMFileSystem createFs(FlowExecutionOwner flowOwner){
-        return FileSystemWrapper.createFromSCM(flowOwner, scm) as SCMFileSystem
+        return FileSystemWrapperFactory.create(flowOwner, scm) as SCMFileSystem
     }
 
     @Extension

--- a/src/main/groovy/org/boozallen/plugins/jte/job/ScmAdHocTemplateFlowDefinitionConfiguration.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/ScmAdHocTemplateFlowDefinitionConfiguration.groovy
@@ -22,6 +22,7 @@ import hudson.scm.SCM
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationDsl
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.kohsuke.stapler.DataBoundConstructor
@@ -54,7 +55,7 @@ class ScmAdHocTemplateFlowDefinitionConfiguration extends AdHocTemplateFlowDefin
     PipelineConfigurationObject getConfig(FlowExecutionOwner flowOwner) throws Exception{
         PipelineConfigurationObject configObject = null
         if (scm && !(scm instanceof NullSCM)){
-            FileSystemWrapper fsw = FileSystemWrapper.createFromSCM(flowOwner, scm)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(flowOwner, scm)
             String configFile = fsw.getFileContents(pipelineConfigurationPath, "Pipeline Configuration File")
             if (configFile){
                 try{
@@ -77,7 +78,7 @@ class ScmAdHocTemplateFlowDefinitionConfiguration extends AdHocTemplateFlowDefin
     String getTemplate(FlowExecutionOwner flowOwner){
         String jenkinsfile = null
         if(scm && !(scm instanceof NullSCM)){
-            FileSystemWrapper fsw = FileSystemWrapper.createFromSCM(flowOwner, scm)
+            FileSystemWrapper fsw = FileSystemWrapperFactory.create(flowOwner, scm)
             jenkinsfile = fsw.getFileContents(this.pipelineTemplatePath, "Template")
         }
         return jenkinsfile

--- a/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapper.groovy
@@ -15,21 +15,9 @@
 */
 package org.boozallen.plugins.jte.util
 
-import hudson.model.ItemGroup
-import hudson.model.TaskListener
-import hudson.scm.SCM
-import jenkins.branch.Branch
 import jenkins.scm.api.SCMFile
 import jenkins.scm.api.SCMFileSystem
-import jenkins.scm.api.SCMHead
-import jenkins.scm.api.SCMRevision
-import jenkins.scm.api.SCMSource
-import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition
-import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
-import org.jenkinsci.plugins.workflow.job.WorkflowJob
-import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty
-import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
 
 /**
  * Utility class to simplify fetching files from remote source code repositories, if the SCM plugin has
@@ -37,29 +25,10 @@ import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
  */
 class FileSystemWrapper {
 
-    SCM scm
     SCMFileSystem fs
     String scmKey
     FlowExecutionOwner owner
 
-    static FileSystemWrapper createFromSCM(FlowExecutionOwner owner, SCM scm){
-        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        fsw.fsFromSCM(scm)
-        return fsw
-    }
-
-    static FileSystemWrapper createFromJob(FlowExecutionOwner owner){
-        FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
-        WorkflowJob job = owner.run().getParent()
-        fsw.fsFrom(job)
-        return fsw
-    }
-
-    /*
-        retrieves a SCMFile if present.
-        if ignoreMissing = true, missing files arent logged.
-        returns null if file not present
-    */
     @SuppressWarnings('ReturnNullFromCatchBlock')
     String getFileContents(String filePath, String loggingDescription = null, Boolean logMissingFile = true) {
         if (!fs) {
@@ -68,6 +37,7 @@ class FileSystemWrapper {
         TemplateLogger logger = new TemplateLogger(owner.getListener())
         try {
             SCMFile f = fs.child(filePath)
+            // The file does not exist
             if (!f.exists()) {
                 if (logMissingFile) {
                     ArrayList msg = [
@@ -78,6 +48,7 @@ class FileSystemWrapper {
                 }
                 return null
             }
+            // the path is not a file
             if (!f.isFile()) {
                 ArrayList msg = [
                     "${filePath} exists but is not a file.",
@@ -86,6 +57,7 @@ class FileSystemWrapper {
                 logger.printWarning(msg.join("\n"))
                 return null
             }
+            // the file exists!
             if (loggingDescription){
                 ArrayList msg = [
                     "Obtained ${loggingDescription}",
@@ -94,7 +66,6 @@ class FileSystemWrapper {
                 ]
                 logger.print(msg.join("\n"))
             }
-
             return f.contentAsString()
         } catch(FileNotFoundException ignored){
             if (logMissingFile) {
@@ -109,77 +80,6 @@ class FileSystemWrapper {
         finally {
             fs.close()
         }
-    }
-
-    List<?> fsFromSCM(SCM scm){
-        WorkflowJob job = owner.run().getParent()
-        if(!scm || !job){
-            return [null, null]
-        }
-
-        try{
-            scmKey = scm.getKey()
-            fs = SCMFileSystem.of(job, scm)
-            return [fs, scmKey]
-        } catch(any){
-            new TemplateLogger(owner.getListener()).printWarning(any.toString())
-            return [null, null]
-        }
-    }
-
-    /*
-        return[0]: SCMFileSystem
-        return[1]: String: key from scm
-    */
-    List<?> fsFrom(WorkflowJob job){
-        ItemGroup<?> parent = job.getParent()
-        TaskListener listener = owner.getListener()
-
-        try {
-            if (parent instanceof WorkflowMultiBranchProject) {
-                // ensure branch is defined
-                BranchJobProperty property = job.getProperty(BranchJobProperty)
-                if (!property) {
-                    throw new JTEException("inappropriate context") // removed IllegalStateEx as an example
-                }
-                Branch branch = property.getBranch()
-
-                // get scm source for specific branch and ensure present
-                // (might not be if branch deleted after job triggered)
-                SCMSource scmSource = parent.getSCMSource(branch.getSourceId())
-                if (!scmSource) {
-                    throw new JTEException(new IllegalStateException("${branch.getSourceId()} not found"))
-                }
-
-                SCMHead head = branch.getHead()
-                SCMRevision tip = scmSource.fetch(head, listener)
-
-                scmKey = branch.getScm().getKey()
-
-                if (tip) {
-                    SCMRevision rev = scmSource.getTrustedRevision(tip, listener)
-                    fs = SCMFileSystem.of(scmSource, head, rev)
-                    return [fs, scmKey]
-                }
-                SCM scm = branch.getScm()
-                fs = SCMFileSystem.of(job, scm)
-                return [fs, scmKey]
-            }
-            FlowDefinition definition = job.getDefinition()
-            if (definition instanceof CpsScmFlowDefinition) {
-                SCM scm = definition.getScm()
-                scmKey = scm.getKey()
-                fs = SCMFileSystem.of(job, scm)
-                return [fs, scmKey]
-            }
-            return [fs, scmKey]
-        } catch(JTEException jteex){ //throw our exception
-            throw (jteex.cause ?: jteex)
-        } catch(any){ // ignore but print every other exception
-            new TemplateLogger(listener).printWarning(any.toString())
-        }
-
-        return [fs, scmKey]
     }
 
     Object asType(Class clazz) {

--- a/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
@@ -1,0 +1,119 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+package org.boozallen.plugins.jte.util
+
+import hudson.model.ItemGroup
+import hudson.model.TaskListener
+import hudson.scm.SCM
+import jenkins.branch.Branch
+import jenkins.scm.api.SCMFileSystem
+import jenkins.scm.api.SCMHead
+import jenkins.scm.api.SCMRevision
+import jenkins.scm.api.SCMSource
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
+
+/**
+ * Creates FileSystemWrappers
+ */
+class FileSystemWrapperFactory {
+
+    /**
+     * Creates a FileSystemWrapper. Can either be provided an SCM directly
+     * or try to infer the SCM from the current job
+     * @param owner the current run
+     * @param scm an optionally provided SCM
+     * @return a FileSystemWrapper
+     */
+    static FileSystemWrapper create(FlowExecutionOwner owner, SCM scm = null){
+        WorkflowRun run = owner.run()
+        WorkflowJob job = run.getParent()
+        if (job == null){
+            throw new IllegalStateException("Job cannot be null when creating FileSystemWrapper")
+        }
+
+        if (scm) {
+            return this.fromSCM(owner, job, scm)
+        }
+
+        ItemGroup<?> parent = job.getParent()
+        if (parent instanceof WorkflowMultiBranchProject) {
+            TaskListener listener = owner.getListener()
+            return this.fromMultiBranchProject(owner, job, listener)
+        }
+
+        FlowDefinition definition = job.getDefinition()
+        if (definition instanceof CpsScmFlowDefinition) {
+            return this.fromPipelineJob(owner, job)
+        }
+
+        throw new IllegalStateException("Unable to build a FileSystemWrapper")
+    }
+
+    private static FileSystemWrapper fromSCM(FlowExecutionOwner owner, WorkflowJob job, SCM scm){
+        SCMFileSystem fs
+        fs = SCMFileSystem.of(job, scm)
+        FileSystemWrapper fsw = new FileSystemWrapper(fs: fs, scmKey: scm.getKey(), owner: owner)
+        return fsw
+    }
+
+    private static FileSystemWrapper fromMultiBranchProject(FlowExecutionOwner owner, WorkflowJob job, TaskListener listener){
+        ItemGroup<?> parent = job.getParent()
+
+        BranchJobProperty property = job.getProperty(BranchJobProperty)
+        if (!property) {
+            throw new JTEException("BranchJobProperty is somehow missing")
+        }
+        Branch branch = property.getBranch()
+
+        SCMSource scmSource = parent.getSCMSource(branch.getSourceId())
+        if (!scmSource) {
+            throw new IllegalStateException("${branch.getSourceId()} not found")
+        }
+
+        SCMHead head = branch.getHead()
+        SCMRevision tip = scmSource.fetch(head, listener)
+
+        SCMFileSystem fs
+        String scmKey
+        if (tip) {
+            scmKey = branch.getScm().getKey()
+            SCMRevision rev = scmSource.getTrustedRevision(tip, listener)
+            fs = SCMFileSystem.of(scmSource, head, rev)
+        } else {
+            SCM job_scm = branch.getScm()
+            fs = SCMFileSystem.of(job, job_scm)
+            scmKey = job_scm.getKey()
+        }
+        FileSystemWrapper fsw = new FileSystemWrapper(fs: fs, scmKey: scmKey, owner: owner)
+        return fsw
+    }
+
+    private static FileSystemWrapper fromPipelineJob(FlowExecutionOwner owner, WorkflowJob job){
+        FlowDefinition definition = job.getDefinition()
+        SCM job_scm = definition.getScm()
+        String scmKey = job_scm.getKey()
+        SCMFileSystem fs = SCMFileSystem.of(job, job_scm)
+        FileSystemWrapper fsw = new FileSystemWrapper(fs: fs, scmKey: scmKey, owner: owner)
+        return fsw
+    }
+
+}

--- a/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
@@ -50,19 +50,28 @@ class FileSystemWrapperFactory {
             throw new IllegalStateException("Job cannot be null when creating FileSystemWrapper")
         }
 
+        FileSystemWrapper fsw
         if (scm) {
-            return this.fromSCM(owner, job, scm)
+            fsw = this.fromSCM(owner, job, scm)
         }
 
         ItemGroup<?> parent = job.getParent()
         if (parent instanceof WorkflowMultiBranchProject) {
             TaskListener listener = owner.getListener()
-            return this.fromMultiBranchProject(owner, job, listener)
+            fsw = this.fromMultiBranchProject(owner, job, listener)
         }
 
         FlowDefinition definition = job.getDefinition()
         if (definition instanceof CpsScmFlowDefinition) {
-            return this.fromPipelineJob(owner, job)
+            fsw = this.fromPipelineJob(owner, job)
+        }
+
+        if(fsw){
+            if(fsw.fs == null){
+                TemplateLogger logger = new TemplateLogger(owner.getListener())
+                logger.printWarning("FileSystemWrapperFactory: Unable to create SCMFileSystem: job: ${job.getFullName()}, scm: ${scm}")
+            }
+            return fsw
         }
 
         throw new IllegalStateException("Unable to build a FileSystemWrapper")

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProviderSpec.groovy
@@ -25,6 +25,7 @@ import jenkins.plugins.git.GitSampleRepoRule
 import jenkins.scm.api.SCMFileSystem
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationDsl
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TestFlowExecutionOwner
 import org.jenkinsci.plugins.workflow.cps.EnvActionImpl
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
@@ -90,7 +91,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getConfig(owner) == null
@@ -112,7 +113,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getConfig(owner).config == [x: 1]
@@ -132,7 +133,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getConfig(owner) == null
@@ -157,7 +158,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getConfig(owner).config == [x: 1]
@@ -172,7 +173,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
             getFileContents(*_) >> 'mock file contents'
         }
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(*_) >> fsw
+        FileSystemWrapperFactory.create(*_) >> fsw
 
         PipelineConfigurationDsl dsl = Mock {
             parse(_) >> { throw new Exception('oops') }
@@ -220,7 +221,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getJenkinsfile(owner) == null
@@ -239,7 +240,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getJenkinsfile(owner) == 'the jenkinsfile'
@@ -260,7 +261,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getJenkinsfile(owner) == 'the jenkinsfile'
@@ -278,7 +279,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getJenkinsfile(owner) == null
@@ -315,7 +316,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getTemplate(owner, 'someTemplate') == null
@@ -334,7 +335,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getTemplate(owner, 'someTemplate') == 'the template'
@@ -355,7 +356,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getTemplate(owner, 'someTemplate') == 'the template'
@@ -373,7 +374,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.getTemplate(owner, 'someTemplate') == null

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/config/ScmPipelineConfigurationProviderSpec.groovy
@@ -90,7 +90,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -112,7 +112,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -132,7 +132,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -157,7 +157,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -172,7 +172,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
         FileSystemWrapper fsw = Mock {
             getFileContents(*_) >> 'mock file contents'
         }
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(*_) >> fsw
 
         PipelineConfigurationDsl dsl = Mock {
@@ -220,7 +220,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -239,7 +239,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -260,7 +260,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -278,7 +278,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -315,7 +315,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -334,7 +334,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -355,7 +355,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -373,7 +373,7 @@ class ScmPipelineConfigurationProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
@@ -70,7 +70,7 @@ class ScmLibraryProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -90,7 +90,7 @@ class ScmLibraryProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -107,7 +107,7 @@ class ScmLibraryProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -167,7 +167,7 @@ class ScmLibraryProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         when:
@@ -203,7 +203,7 @@ class ScmLibraryProviderSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         when:
@@ -230,7 +230,7 @@ class ScmLibraryProviderSpec extends Specification {
         owner.getRootDir() >> rootDir
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -254,7 +254,7 @@ class ScmLibraryProviderSpec extends Specification {
         owner.getRootDir() >> rootDir
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -279,7 +279,7 @@ class ScmLibraryProviderSpec extends Specification {
         owner.getRootDir() >> rootDir
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
@@ -303,7 +303,7 @@ class ScmLibraryProviderSpec extends Specification {
         owner.getRootDir() >> rootDir
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:

--- a/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProviderSpec.groovy
@@ -24,6 +24,7 @@ import hudson.plugins.git.extensions.GitSCMExtension
 import jenkins.plugins.git.GitSampleRepoRule
 import jenkins.scm.api.SCMFileSystem
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TestFlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
@@ -70,7 +71,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.hasLibrary(owner, libraryName)
@@ -90,7 +91,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.hasLibrary(owner, libraryName)
@@ -107,7 +108,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         !p.hasLibrary(owner, libraryName)
@@ -167,7 +168,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         when:
         p.loadLibrary(owner, libraryName, srcDir, libDir)
@@ -203,7 +204,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         when:
         p.loadLibrary(owner, libraryName, srcDir, libDir)
@@ -230,7 +231,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.hasLibrary(owner, libraryName)
@@ -254,7 +255,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.hasLibrary(owner, libraryName)
@@ -279,7 +280,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         p.hasLibrary(owner, libraryName)
@@ -303,7 +304,7 @@ class ScmLibraryProviderSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: owner)
         fsw.fs = SCMFileSystem.of(job, scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(owner, scm) >> fsw
+        FileSystemWrapperFactory.create(owner, scm) >> fsw
 
         expect:
         !p.hasLibrary(owner, libraryName)

--- a/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
@@ -25,6 +25,7 @@ import jenkins.plugins.git.GitSampleRepoRule
 import jenkins.scm.api.SCMFileSystem
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.util.FileSystemWrapper
+import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TestFlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
@@ -92,7 +93,7 @@ class AdHocTemplateFlowDefinitionSpec extends Specification {
         FileSystemWrapper fsw = new FileSystemWrapper(owner: flowOwner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(flowOwner, scm) >> fsw
+        FileSystemWrapperFactory.create(flowOwner, scm) >> fsw
 
         def definition = new AdHocTemplateFlowDefinition(flowDefConfig)
 
@@ -129,7 +130,7 @@ keywords{
         FileSystemWrapper fsw = new FileSystemWrapper(owner: flowOwner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
         GroovySpy(FileSystemWrapper, global: true)
-        FileSystemWrapper.createFromSCM(flowOwner, scm) >> fsw
+        FileSystemWrapperFactory.create(flowOwner, scm) >> fsw
 
         def definition = new AdHocTemplateFlowDefinition(flowDefConfig)
         when:

--- a/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/job/AdHocTemplateFlowDefinitionSpec.groovy
@@ -92,7 +92,7 @@ class AdHocTemplateFlowDefinitionSpec extends Specification {
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: flowOwner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(flowOwner, scm) >> fsw
 
         def definition = new AdHocTemplateFlowDefinition(flowDefConfig)
@@ -129,7 +129,7 @@ keywords{
 
         FileSystemWrapper fsw = new FileSystemWrapper(owner: flowOwner)
         fsw.fs = SCMFileSystem.of(jenkins.createProject(WorkflowJob), scm)
-        GroovySpy(FileSystemWrapper, global: true)
+        GroovySpy(FileSystemWrapperFactory, global: true)
         FileSystemWrapperFactory.create(flowOwner, scm) >> fsw
 
         def definition = new AdHocTemplateFlowDefinition(flowDefConfig)


### PR DESCRIPTION
# PR Details

A long awaited refactoring of how `FileSystemWrapper` works.

## Description

### The Issue
`FileSystemWrapper`, previously, had static constructor methods that would instantiate an instance and then instance methods to populate the object's fields. 

These instance methods had multiple return parameters and overall made the code hard to reason about.

Furthermore, the creation of a `FileSystemWrapper` would swallow exceptions without logging them.

### The Resolution

`FileSystemWrapper` has been split into two classes.  A `FileSystemWrapperFactory` now handles the creation of `FileSystemWrapper` objects through a single `create` method. 

Most exception handling has been removed so as to surface unexpected behavior when JTE is unable to fetch files.

## How Has This Been Tested

Unit Tests have been refactored to pass.

TODO: integration testing on a real Jenkins with various SCM providers:
- [ ] GitHub
- [ ] a local git repo
- [ ] GitLab
- [ ] BitBucket Cloud

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
