### PR TITLE
Add backwards compatibility from 2.3 

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
@@ -16,16 +16,8 @@
 package org.boozallen.plugins.jte.init
 
 import org.boozallen.plugins.jte.init.governance.GovernanceTier
-import org.boozallen.plugins.jte.init.governance.config.ScmPipelineConfigurationProvider
-import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationDsl
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
-import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
-import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.job.TemplateFlowDefinition
-import org.boozallen.plugins.jte.util.FileSystemWrapper
-import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
-import org.boozallen.plugins.jte.util.TemplateLogger
-import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineConfigurationAggregator.groovy
@@ -21,6 +21,7 @@ import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfiguratio
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
 import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
+import org.boozallen.plugins.jte.job.TemplateFlowDefinition
 import org.boozallen.plugins.jte.util.FileSystemWrapper
 import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
@@ -69,32 +70,8 @@ class PipelineConfigurationAggregator {
     }
 
     PipelineConfigurationObject getJobPipelineConfiguration(){
-        PipelineConfigurationObject jobConfig = null
-        FlowDefinition flowDefinition = job.getDefinition()
-        if(flowDefinition instanceof AdHocTemplateFlowDefinition){
-            jobConfig = flowDefinition.getPipelineConfiguration(flowOwner)
-        } else {
-            // get job config if present
-            FileSystemWrapper fsw = FileSystemWrapperFactory.create(flowOwner)
-            // enable custom path to config file instead of default pipeline_config.groovy at root
-            String configurationPath
-            if (flowDefinition instanceof MultibranchTemplateFlowDefinition) {
-                configurationPath = flowDefinition.getConfigurationPath()
-            } else {
-                configurationPath = ScmPipelineConfigurationProvider.CONFIG_FILE
-            }
-            String repoConfigFile = fsw.getFileContents(configurationPath, "Template Configuration File", false)
-            if (repoConfigFile){
-                try{
-                    jobConfig = new PipelineConfigurationDsl(flowOwner).parse(repoConfigFile)
-                } catch(any){
-                    TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-                    logger.printError("Error parsing ${job.getName()}'s configuration file in SCM.")
-                    throw any
-                }
-            }
-        }
-        return jobConfig
+        TemplateFlowDefinition flowDefinition = job.getDefinition()
+        return flowDefinition.getPipelineConfiguration(flowOwner)
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/PipelineTemplateResolver.groovy
@@ -18,12 +18,8 @@ package org.boozallen.plugins.jte.init
 import org.boozallen.plugins.jte.init.governance.GovernanceTier
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.job.AdHocTemplateFlowDefinition
-import org.boozallen.plugins.jte.job.MultibranchTemplateFlowDefinition
 import org.boozallen.plugins.jte.job.TemplateFlowDefinition
-import org.boozallen.plugins.jte.util.FileSystemWrapper
-import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.TemplateLogger
-import org.jenkinsci.plugins.workflow.flow.FlowDefinition
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 
@@ -52,13 +48,12 @@ class PipelineTemplateResolver {
             if (flowDefinition instanceof AdHocTemplateFlowDefinition){
                 logger.print "Obtained Pipeline Template from job configuration"
                 return template
-            } else {
-                // templates from SCM depend on Pipeline Configuration
-                if (jteBlockWrapper.allow_scm_jenkinsfile){
-                    return template
-                }
-                logger.printWarning "Repository provided Jenkinsfile that will not be used, per organizational policy."
             }
+            // templates from SCM depend on Pipeline Configuration
+            if (jteBlockWrapper.allow_scm_jenkinsfile){
+                return template
+            }
+            logger.printWarning "Repository provided Jenkinsfile that will not be used, per organizational policy."
         }
 
         List<GovernanceTier> tiers = GovernanceTier.getHierarchy(job)

--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/ScmLibraryProvider.groovy
@@ -21,7 +21,6 @@ import hudson.Util
 import hudson.scm.SCM
 import jenkins.scm.api.SCMFile
 import jenkins.scm.api.SCMFileSystem
-import org.boozallen.plugins.jte.util.FileSystemWrapper
 import org.boozallen.plugins.jte.util.FileSystemWrapperFactory
 import org.boozallen.plugins.jte.util.JTEException
 import org.boozallen.plugins.jte.util.TemplateLogger

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateBranchProjectFactory.groovy
@@ -16,6 +16,7 @@
 package org.boozallen.plugins.jte.job
 
 import hudson.Extension
+import hudson.Util
 import hudson.model.TaskListener
 import jenkins.branch.MultiBranchProject
 import jenkins.scm.api.SCMFile
@@ -56,7 +57,7 @@ class TemplateBranchProjectFactory extends WorkflowBranchProjectFactory {
 
     @DataBoundSetter
     void setConfigurationPath(String configurationPath){
-        this.configurationPath = configurationPath
+        this.configurationPath = Util.fixEmptyAndTrim(configurationPath) ?: ScmPipelineConfigurationProvider.CONFIG_FILE
     }
 
     String getConfigurationPath(){

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateFlowDefinition.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateFlowDefinition.groovy
@@ -82,4 +82,18 @@ abstract class TemplateFlowDefinition extends FlowDefinition {
         return template
     }
 
+    /**
+     * Fetch the job's Pipeline Configuration
+     * @param flowOwner
+     * @return Pipeline Configuration if present, null otherwise
+     */
+    abstract PipelineConfigurationObject getPipelineConfiguration(FlowExecutionOwner flowOwner)
+
+    /**
+     * Fetch the job's Pipeline Template, if present
+     * @param flowOwner
+     * @return template if present, null otherwise
+     */
+    abstract String getTemplate(FlowExecutionOwner flowOwner)
+
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateMultiBranchProjectFactory.groovy
@@ -16,6 +16,7 @@
 package org.boozallen.plugins.jte.job
 
 import hudson.Extension
+import hudson.Util
 import hudson.model.Action
 import hudson.model.ItemGroup
 import hudson.model.Item
@@ -65,7 +66,7 @@ class TemplateMultiBranchProjectFactory extends MultiBranchProjectFactory.BySCMS
 
     @DataBoundSetter
     void setScriptPath(String scriptPath){
-        this.scriptPath = scriptPath
+        this.scriptPath = Util.fixEmptyAndTrim(scriptPath) ?: 'Jenkinsfile'
     }
 
     String getScriptPath(){
@@ -74,7 +75,7 @@ class TemplateMultiBranchProjectFactory extends MultiBranchProjectFactory.BySCMS
 
     @DataBoundSetter
     void setConfigurationPath(String configurationPath){
-        this.configurationPath = configurationPath
+        this.configurationPath = Util.fixEmptyAndTrim(configurationPath) ?: ScmPipelineConfigurationProvider.CONFIG_FILE
     }
 
     String getConfigurationPath(){

--- a/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/FileSystemWrapperFactory.groovy
@@ -108,9 +108,9 @@ class FileSystemWrapperFactory {
             SCMRevision rev = scmSource.getTrustedRevision(tip, listener)
             fs = SCMFileSystem.of(scmSource, head, rev)
         } else {
-            SCM job_scm = branch.getScm()
-            fs = SCMFileSystem.of(job, job_scm)
-            scmKey = job_scm.getKey()
+            SCM jobSCM = branch.getScm()
+            fs = SCMFileSystem.of(job, jobSCM)
+            scmKey = jobSCM.getKey()
         }
         FileSystemWrapper fsw = new FileSystemWrapper(fs: fs, scmKey: scmKey, owner: owner)
         return fsw
@@ -118,9 +118,9 @@ class FileSystemWrapperFactory {
 
     private static FileSystemWrapper fromPipelineJob(FlowExecutionOwner owner, WorkflowJob job){
         FlowDefinition definition = job.getDefinition()
-        SCM job_scm = definition.getScm()
-        String scmKey = job_scm.getKey()
-        SCMFileSystem fs = SCMFileSystem.of(job, job_scm)
+        SCM jobSCM = definition.getScm()
+        String scmKey = jobSCM.getKey()
+        SCMFileSystem fs = SCMFileSystem.of(job, jobSCM)
         FileSystemWrapper fsw = new FileSystemWrapper(fs: fs, scmKey: scmKey, owner: owner)
         return fsw
     }

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidatorSpec.groovy
@@ -29,7 +29,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 import org.junit.Rule
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.WithoutJenkins
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Specification
 


### PR DESCRIPTION
# PR Details

fixes #264 
PR #252 inadvertently broke backwards compatibility by adding fields without a corresponding entry in `readResolve`.

## Description

This PR addresses that bug while simplifying some of the code contributed via the addition of abstract methods on `TemplateFlowDefinition`. 

Each extension of `TemplateFlowDefinition` must now implement `getPipelineConfiguration` and `getTemplate` methods to avoid conditional statements in `PipelineConfigurationAggregator` and `PipelineTemplateResolver` based on the class of the `FlowDefinition`. 

## How Has This Been Tested

unit tests all continue to pass.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
