### PR TITLE
Ensure pipeline's can resume when Jenkins restarts mid-step

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -16,10 +16,8 @@
 package org.boozallen.plugins.jte.init.primitives.injectors
 
 import groovy.transform.AutoClone
-import hudson.Extension
 import hudson.FilePath
 import jenkins.model.Jenkins
-import jenkins.security.CustomClassFilter
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
@@ -28,9 +26,6 @@ import org.boozallen.plugins.jte.util.JTEException
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 import org.jenkinsci.plugins.workflow.cps.CpsThread
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
-import org.jenkinsci.plugins.workflow.pickles.Pickle
-import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory
-import org.jenkinsci.plugins.workflow.support.pickles.XStreamPickle
 
 /**
  * A library step

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -36,7 +36,7 @@ class StepWrapper extends TemplatePrimitive implements Serializable{
 
     private static final long serialVersionUID = 1L
 
-    /**a
+    /**
      * The library configuration
      */
     protected LinkedHashMap config

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
@@ -1,0 +1,82 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+package org.boozallen.plugins.jte.init.primitives.injectors
+
+import hudson.Extension
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
+import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector.StageContext
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.pickles.Pickle
+import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory
+import org.jenkinsci.plugins.workflow.support.pickles.TryRepeatedly
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * responsible for rehydrating compiled steps
+ * required to successfully resume a pipeline that
+ * restarts mid-step execution
+ */
+class StepWrapperScriptPickle extends Pickle{
+
+    private StepContext stepContext
+    private HookContext hookContext
+    private StageContext stageContext
+
+    private StepWrapperScriptPickle(StepWrapperScript script){
+        stepContext = script.getStepContext()
+        hookContext = script.getHookContext()
+        stageContext = script.getStageContext()
+    }
+
+    @Override
+    ListenableFuture<StepWrapperScript> rehydrate(FlowExecutionOwner flowOwner){
+        return new TryRepeatedly<StepWrapperScript>(1, 0){
+            @Override
+            protected StepWrapperScript tryResolve(){
+                WorkflowRun run = flowOwner.run()
+                TemplatePrimitiveCollector jte = run.getAction(TemplatePrimitiveCollector)
+                if (jte == null){
+                    throw new IllegalStateException("Unable to unmarshal StepWrapperScript")
+                }
+                List<TemplatePrimitive> steps = jte.getSteps(stepContext.name)
+                StepWrapper step = steps.find{ StepWrapper step ->
+                    step.getName() == stepContext.name &&
+                    step.getLibrary() == stepContext.library
+                }
+                if (step == null){
+                    throw new IllegalStateException(("Unable to determine StepWrapper"))
+                }
+                StepWrapperScript script = step.getScript(flowOwner)
+                script.setStepContext(stepContext)
+                script.setHookContext(hookContext)
+                script.setStageContext(stageContext)
+                return script
+            }
+        }
+    }
+
+    @Extension
+    static final class Pickler extends SingleTypedPickleFactory<StepWrapperScript>{
+        @Override
+        protected Pickle pickle(StepWrapperScript script){
+            return new StepWrapperScriptPickle(script)
+        }
+    }
+
+}

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
@@ -34,9 +34,9 @@ import com.google.common.util.concurrent.ListenableFuture
  */
 class StepWrapperScriptPickle extends Pickle{
 
-    private StepContext stepContext
-    private HookContext hookContext
-    private StageContext stageContext
+    private final StepContext stepContext
+    private final HookContext hookContext
+    private final StageContext stageContext
 
     private StepWrapperScriptPickle(StepWrapperScript script){
         stepContext = script.getStepContext()

--- a/src/test/groovy/org/boozallen/plugins/jte/init/ResumabilitySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/ResumabilitySpec.groovy
@@ -17,6 +17,7 @@ package org.boozallen.plugins.jte.init
 
 import org.junit.Rule
 import org.jvnet.hudson.test.RestartableJenkinsRule
+import spock.lang.Issue
 import spock.lang.Specification
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
@@ -131,6 +132,7 @@ class ResumabilitySpec extends Specification {
         }
     }
 
+    @Issue("https://github.com/jenkinsci/templating-engine-plugin/issues/191")
     def "Restart mid-step resumes successfully"() {
         when:
         story.then { jenkins ->


### PR DESCRIPTION
# PR Details

fixes #191 

## Description

Adds a `StepWrapperScriptPickle` to assist in unmarshalling a compiled step during pipeline resumption.

## How Has This Been Tested

Reproduced error via unit tests
Tests pass. 

Reproduced error in a live Jenkins and validated fix.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
