### PR TITLE
Resolve pipeline replay failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           arguments: --no-daemon codenarc
       - uses: actions/upload-artifact@v1
+        if: failure()
         with:
           name: codenarc-results
           path: build/reports
@@ -42,6 +43,7 @@ jobs:
       with:
         arguments: --no-daemon test jacocoTestReport
     - uses: actions/upload-artifact@v1
+      if: failure()
       with:
         name: test-results
         path: build/reports

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,15 +4,6 @@ on:
     branches: 
       - main
 jobs:
-  printJob:    
-    name: Print event
-    runs-on: ubuntu-latest
-    steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: |
-        echo "$GITHUB_CONTEXT"
   Spotless:
     runs-on: ubuntu-latest
     if: github.repository == 'jenkinsci/templating-engine-plugin'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,15 @@ on:
     branches: 
       - main
 jobs:
+  printJob:    
+    name: Print event
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT"
   Spotless:
     runs-on: ubuntu-latest
     if: github.repository == 'jenkinsci/templating-engine-plugin'

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
@@ -49,6 +49,9 @@ class StepWrapperScriptPickle extends Pickle{
         return new TryRepeatedly<StepWrapperScript>(1, 0){
             @Override
             protected StepWrapperScript tryResolve(){
+                if(flowOwner == null){
+                    return null
+                }
                 WorkflowRun run = flowOwner.run()
                 TemplatePrimitiveCollector jte = run.getAction(TemplatePrimitiveCollector)
                 if (jte == null){

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
@@ -60,7 +60,7 @@ class StepWrapperScriptPickle extends Pickle{
                     step.getLibrary() == stepContext.library
                 }
                 if (step == null){
-                    throw new IllegalStateException(("Unable to determine StepWrapper"))
+                    throw new IllegalStateException("Unable to determine StepWrapper")
                 }
                 StepWrapperScript script = step.getScript(flowOwner)
                 script.setStepContext(stepContext)

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapperScriptPickle.groovy
@@ -49,9 +49,6 @@ class StepWrapperScriptPickle extends Pickle{
         return new TryRepeatedly<StepWrapperScript>(1, 0){
             @Override
             protected StepWrapperScript tryResolve(){
-                if(flowOwner == null){
-                    return null
-                }
                 WorkflowRun run = flowOwner.run()
                 TemplatePrimitiveCollector jte = run.getAction(TemplatePrimitiveCollector)
                 if (jte == null){

--- a/src/test/groovy/org/boozallen/plugins/jte/ReplaySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/ReplaySpec.groovy
@@ -1,3 +1,18 @@
+/*
+    Copyright 2018 Booz Allen Hamilton
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
 package org.boozallen.plugins.jte
 
 import org.boozallen.plugins.jte.util.TestUtil
@@ -39,7 +54,7 @@ class ReplaySpec extends Specification{
         then:
         WorkflowRun b2 = b1.getAction(ReplayAction).run(template, [:]).get()
         jenkins.assertBuildStatusSuccess(b2)
-        jenkins.assertLogContains("hello world")
-
+        jenkins.assertLogContains("hello world", b2)
     }
+
 }

--- a/src/test/groovy/org/boozallen/plugins/jte/ReplaySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/ReplaySpec.groovy
@@ -1,0 +1,45 @@
+package org.boozallen.plugins.jte
+
+import org.boozallen.plugins.jte.util.TestUtil
+import org.jenkinsci.plugins.workflow.cps.replay.ReplayAction
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.junit.ClassRule
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ReplaySpec extends Specification{
+
+    @Shared @ClassRule JenkinsRule jenkins = new JenkinsRule()
+
+    @Issue("https://github.com/jenkinsci/templating-engine-plugin/issues/222")
+    def "replay declarative pipeline and access keyword"(){
+        when:
+        String template = '''
+        pipeline{
+          agent any
+          stages{
+            stage("stage"){
+              steps{
+                echo message
+              }
+            }
+          }
+        }
+        '''
+        WorkflowJob p = TestUtil.createAdHoc(
+                config: 'keywords{ message = "hello world" }',
+                template: template, jenkins, 'p'
+        )
+        then:
+        WorkflowRun b1 = jenkins.assertBuildStatusSuccess(p.scheduleBuild2(0))
+        jenkins.assertLogContains("hello world", b1)
+        then:
+        WorkflowRun b2 = b1.getAction(ReplayAction).run(template, [:]).get()
+        jenkins.assertBuildStatusSuccess(b2)
+        jenkins.assertLogContains("hello world")
+
+    }
+}

--- a/src/test/groovy/org/boozallen/plugins/jte/ResumabilitySpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/ResumabilitySpec.groovy
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-package org.boozallen.plugins.jte.init
+package org.boozallen.plugins.jte
 
 import org.junit.Rule
 import org.jvnet.hudson.test.RestartableJenkinsRule


### PR DESCRIPTION
# PR Details

fixes #222 
fixes #225 

## Description

The `TemplatePrimitiveCollector` action that's responsible for giving the pipeline access to `TemplatePrimitive`s was not being added for replays of pipelines.

## How Has This Been Tested

unit tests reproduced the error and then passed with the fix. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
