### PR TITLE
Resolve bug in plugin-provided library sources requiring a `src` directory.

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -125,7 +125,7 @@ class PluginLibraryProvider extends LibraryProvider{
         Boolean hasSteps = (libraries[libName])?.steps as Boolean
         Boolean hasClasses = (libraries[libName])?.src as Boolean
 
-        if( !hasSteps || !hasClasses){ // library has no steps
+        if( !hasSteps && !hasClasses){ // library has no steps
             TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
             logger.printWarning("Library ${libName} exists but does not have any steps or classes. Will not be loaded.")
             return false


### PR DESCRIPTION
# PR Details

fixes #268 

all credit goes to @connorh23 for finding the fix! 

## Description

The `PluginLibraryProvider` was mistaking checking if a library didn't have a `src` directory _**or**_ a `steps` directory instead of checking that **both** don't exist. 

## How Has This Been Tested

error reproduced and fix validated manually. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
