### PR TITLE
Simplify the `TemplatePrimitiveInjector` interfaces

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/hooks/HookInjector.groovy
@@ -19,6 +19,7 @@ import hudson.Extension
 import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
+import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 
 /**
@@ -42,9 +43,10 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
     }
 
     @Override
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         getHooksClass()
         getAnnotatedMethodClass()
+        return null
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
@@ -17,11 +17,9 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 
 import hudson.Extension
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 /**
  * creates ApplicationEnvironments
@@ -32,8 +30,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
     @SuppressWarnings('NoDef')
     @Override
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config) {
-        FlowExecutionOwner flowOwner = exec.getOwner()
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config) {
         TemplatePrimitiveNamespace appEnvs = new TemplatePrimitiveNamespace(name: KEY)
 
         // populate the namespace with application environments from pipeline config
@@ -52,12 +49,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             appEnvs.add(env)
         }
 
-        // add the namespace to the collector and save it on the run
-        if(appEnvs.getPrimitives()) {
-            TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
-            primitiveCollector.addNamespace(appEnvs)
-            flowOwner.run().addOrReplaceAction(primitiveCollector)
-        }
+        return appEnvs.getPrimitives() ? appEnvs : null
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
@@ -34,7 +34,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
     @Override
     @RunAfter(LibraryStepInjector)
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         FlowExecutionOwner flowOwner = exec.getOwner()
         TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
         TemplatePrimitiveNamespace steps = new TemplatePrimitiveNamespace(name: KEY)
@@ -59,11 +59,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             }
         }
 
-        // add the namespace to the collector and save it on the run
-        if(steps.getPrimitives()) {
-            primitiveCollector.addNamespace(steps)
-            flowOwner.run().addOrReplaceAction(primitiveCollector)
-        }
+        return steps.getPrimitives() ? steps : null
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/GlobalCollisionValidator.groovy
@@ -33,13 +33,12 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 @Extension class GlobalCollisionValidator extends TemplatePrimitiveInjector{
 
     @Override
-    void validatePrimitives(CpsFlowExecution exec, PipelineConfigurationObject config) {
+    void validatePrimitives(CpsFlowExecution exec, PipelineConfigurationObject config, TemplatePrimitiveCollector collector) {
         FlowExecutionOwner flowOwner = exec.getOwner()
         TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-        TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
 
         Map<String, List<TemplatePrimitive>> primitivesByName = [:]
-        primitiveCollector.getPrimitives().each{ primitive ->
+        collector.getPrimitives().each{ primitive ->
             String name = primitive.getName()
             if(!primitivesByName.containsKey(name)){
                 primitivesByName[name] = []
@@ -51,13 +50,6 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor
         checkForGlobalVariableCollisions(primitivesByName, flowOwner, logger)
         checkForJenkinsStepCollisions(primitivesByName, logger)
     }
-
-    /*
-
-        [
-          build: [ maven, gradle ]
-        ]
-     */
 
     void checkForPrimitiveCollisions(Map<String, List<TemplatePrimitive>> primitivesByName, PipelineConfigurationObject config, TemplateLogger logger){
         Map primitiveCollisions = primitivesByName.findAll{ key, value -> value.size() > 1 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
@@ -17,11 +17,9 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 
 import hudson.Extension
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 /**
  * creates Keywords
@@ -31,8 +29,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
     private static final String KEY = "keywords"
 
     @Override
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
-        FlowExecutionOwner flowOwner = exec.getOwner()
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         TemplatePrimitiveNamespace keywords = new TemplatePrimitiveNamespace(name: KEY)
 
         // populate namespace with keywords from pipeline config
@@ -43,12 +40,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             keywords.add(keyword)
         }
 
-        // add the namespace to the collector and save it on the run
-        if(keywords.getPrimitives()) {
-            TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
-            primitiveCollector.addNamespace(keywords)
-            flowOwner.run().addOrReplaceAction(primitiveCollector)
-        }
+        return keywords.getPrimitives() ? keywords : null
     }
 
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjector.groovy
@@ -21,7 +21,6 @@ import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfiguratio
 import org.boozallen.plugins.jte.init.governance.GovernanceTier
 import org.boozallen.plugins.jte.init.governance.libs.LibraryProvider
 import org.boozallen.plugins.jte.init.governance.libs.LibrarySource
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.boozallen.plugins.jte.util.AggregateException
@@ -81,7 +80,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob
     }
 
     @Override
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         FlowExecutionOwner flowOwner = exec.getOwner()
         // fetch library providers and determine library resolution order
         List<LibraryProvider> providers = getLibraryProviders(flowOwner)
@@ -137,11 +136,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob
             }
         }
 
-        if(libCollector.getLibraries()) {
-            TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
-            primitiveCollector.addNamespace(libCollector)
-            flowOwner.run().addOrReplaceAction(primitiveCollector)
-        }
+        return libCollector.getPrimitives() ? libCollector : null
     }
 
     /**

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/PipelineConfigVariableInjector.groovy
@@ -18,12 +18,10 @@ package org.boozallen.plugins.jte.init.primitives.injectors
 import hudson.Extension
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
-import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.cps.CpsScript
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 import javax.annotation.Nonnull
 
@@ -36,17 +34,13 @@ import javax.annotation.Nonnull
 
     @SuppressWarnings('NoDef')
     @Override
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
-        FlowExecutionOwner flowOwner = exec.getOwner()
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         PipelineConfigGlobalVariable pipelineConfig = new PipelineConfigGlobalVariable(config.getConfig())
         TemplatePrimitiveNamespace pipelineConfigNamespace = new TemplatePrimitiveNamespace(name: KEY)
         pipelineConfig.setParent(pipelineConfigNamespace)
         pipelineConfigNamespace.add(pipelineConfig)
 
-        // add the namespace to the collector and save it on the run
-        TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
-        primitiveCollector.addNamespace(pipelineConfigNamespace)
-        flowOwner.run().addOrReplaceAction(primitiveCollector)
+        return pipelineConfigNamespace
     }
 
     class PipelineConfigGlobalVariable extends TemplatePrimitive{

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/TemplateMethodInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/TemplateMethodInjector.groovy
@@ -22,7 +22,6 @@ import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
-import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 
 /**
  * creates no-op steps based on the pipeline configuration
@@ -34,8 +33,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
     @SuppressWarnings("ParameterName")
     @Override
     @RunAfter([LibraryStepInjector, DefaultStepInjector])
-    void injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
-        FlowExecutionOwner flowOwner = exec.getOwner()
+    TemplatePrimitiveNamespace injectPrimitives(CpsFlowExecution exec, PipelineConfigurationObject config){
         TemplatePrimitiveCollector primitiveCollector = getPrimitiveCollector(exec)
         TemplatePrimitiveNamespace steps = new TemplatePrimitiveNamespace(name: KEY)
 
@@ -50,11 +48,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             }
         }
 
-        // add the namespace to the collector and save it on the run
-        if(steps.getPrimitives()) {
-            primitiveCollector.addNamespace(steps)
-            flowOwner.run().addOrReplaceAction(primitiveCollector)
-        }
+        return steps.getPrimitives() ? steps : null
     }
 
 }


### PR DESCRIPTION
# PR Details

Previously - each `TemplatePrimitiveInjector` was responsible for fetching the run's `TemplatePrimitiveCollector`, adding a `TemplatePrimitiveNamespace` to it, and then saving it back to the run in the right way. 

To simplify this... this PR changes the interface so that `TemplatePrimitiveInjector.injectPrimitives(...)` is expected to just return a `TemplatePrimitiveNamespace`.

Similarly, the `TemplatePrimitiveNamespace.validatePrimitives(...)` interface now receives the `TemplatePrimitiveCollector` as an argument so it doesn't have to fetch the collector itself. 

## How Has This Been Tested

unit tests pass after refactor

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
