### PR TITLE
Add Configuration Validation to Application Environment parsing

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveInjector.groovy
@@ -21,7 +21,6 @@ import jenkins.model.Jenkins
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.util.AggregateException
 import org.boozallen.plugins.jte.util.JTEException
-import org.boozallen.plugins.jte.util.TemplateLogger
 import org.codehaus.groovy.reflection.CachedMethod
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.cps.CpsGroovyShellFactory
@@ -155,16 +154,14 @@ abstract class TemplatePrimitiveInjector implements ExtensionPoint{
                     namespaces << injector.invokeMethod(phase, args)
                 }
             } catch(any){
-                CpsFlowExecution exec = args[0]
-                FlowExecutionOwner flowOwner = exec.getOwner()
-                TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-                String msg = [ any.getMessage(), any.getStackTrace()*.toString() ].flatten().join("\n")
-                logger.printError(msg)
                 errors.add(any)
                 failedInjectors << injectorClazz
             }
         }
         if(errors.size()) { // this phase failed throw an exception
+            CpsFlowExecution exec = args[0]
+            errors.printToConsole(exec)
+            errors.setMessage("JTE Pipeline Initialization failed during ${phase}")
             throw errors
         }
         return namespaces

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentInjector.groovy
@@ -19,6 +19,8 @@ import hudson.Extension
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationObject
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveInjector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
+import org.boozallen.plugins.jte.util.AggregateException
+import org.boozallen.plugins.jte.util.JTEException
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 
 /**
@@ -27,6 +29,20 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 @Extension class ApplicationEnvironmentInjector extends TemplatePrimitiveInjector {
 
     static private final String KEY = "application_environments"
+
+    @Override
+    void validateConfiguration(CpsFlowExecution exec, PipelineConfigurationObject config){
+        LinkedHashMap aggregatedConfig = config.getConfig()
+        AggregateException errors = new AggregateException()
+        aggregatedConfig[KEY].each { name, appEnvConfig ->
+            if(!(appEnvConfig in Map)){
+                errors.add(new JTEException("Configuration for Application Environment ${name} must be a Block but is a ${appEnvConfig.getClass().getSimpleName()}"))
+            }
+        }
+        if(errors.size()){
+            throw errors
+        }
+    }
 
     @SuppressWarnings('NoDef')
     @Override

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjector.groovy
@@ -59,15 +59,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob
                 String schema = provider.getLibrarySchema(flowOwner, libName)
                 if(schema){
                     try {
-                        validator.validate(schema, libConfig)
+                        validator.validate(schema, libConfig, "Library ${libName}")
                     } catch (AggregateException e) {
-                        TemplateLogger logger = new TemplateLogger(flowOwner.getListener())
-                        String errorHeader = "Library ${libName} has configuration errors"
-                        logger.printError(errorHeader)
-                        e.getExceptions().eachWithIndex{ error, idx ->
-                            logger.printError("${idx + 1}. ${error.getMessage()}".toString())
-                        }
-                        errors.add(new JTEException(errorHeader))
+                        errors.add(e)
                     }
                 }
             } else {

--- a/src/main/groovy/org/boozallen/plugins/jte/util/ConfigValidator.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/ConfigValidator.groovy
@@ -30,13 +30,13 @@ class ConfigValidator {
         this.flowOwner = flowOwner
     }
 
-    void validate(String schemaString, LinkedHashMap config){
+    void validate(String schemaString, LinkedHashMap config, String msgPrefix = ""){
         LinkedHashMap schema = parseSchema(schemaString)
-        validate(schema, config)
+        validate(schema, config, msgPrefix)
     }
 
     @SuppressWarnings('NoDef')
-    void validate(LinkedHashMap schema, LinkedHashMap config) throws AggregateException{
+    void validate(LinkedHashMap schema, LinkedHashMap config, String msgPrefix = "") throws AggregateException{
         // define key sets in dot notation
         List<String> keys = getNestedKeys(config)
         List<String> required = getNestedKeys(schema.fields?.required)
@@ -55,16 +55,16 @@ class ConfigValidator {
                 if (keyHasError){
                     String msg
                     if (expected instanceof java.util.regex.Pattern){
-                        msg = "Field ${requiredKey} must be a String matching ${expected} but is [${actual}]"
+                        msg = "field ${requiredKey} must be a String matching ${expected} but is [${actual}]"
                     } else if (expected instanceof ArrayList){
-                        msg = "Field '${requiredKey}' must be one of ${expected} but is [${actual}]"
+                        msg = "field '${requiredKey}' must be one of ${expected} but is [${actual}]"
                     } else {
-                        msg = "Field '${requiredKey}' must be a ${expected.getSimpleName()} but is a ${actual.getClass().getSimpleName()}"
+                        msg = "field '${requiredKey}' must be a ${expected.getSimpleName()} but is a ${actual.getClass().getSimpleName()}"
                     }
-                    errors.add(new JTEException(msg))
+                    errors.add(new JTEException("${msgPrefix ? "${msgPrefix} " : ""}${msg}"))
                 }
             } else{
-                errors.add(new JTEException("Missing required field '${requiredKey}'"))
+                errors.add(new JTEException("${msgPrefix ? "${msgPrefix} " : ""}missing required field '${requiredKey}'"))
             }
         }
 
@@ -78,20 +78,20 @@ class ConfigValidator {
                 if (keyHasError){
                     String msg
                     if (expected instanceof java.util.regex.Pattern){
-                        msg = "Field ${optionalKey} must be a String matching ${expected} but is [${actual}]"
+                        msg = "field ${optionalKey} must be a String matching ${expected} but is [${actual}]"
                     } else if (expected instanceof ArrayList){
-                        msg = "Field '${optionalKey}' must be one of ${expected} but is [${actual}]"
+                        msg = "field '${optionalKey}' must be one of ${expected} but is [${actual}]"
                     } else {
-                        msg = "Field '${optionalKey}' must be a ${expected.getSimpleName()} but is a ${actual.getClass().getSimpleName()}"
+                        msg = "field '${optionalKey}' must be a ${expected.getSimpleName()} but is a ${actual.getClass().getSimpleName()}"
                     }
-                    errors.add(new JTEException(msg))
+                    errors.add(new JTEException("${msgPrefix ? "${msgPrefix} " : ""}${msg}"))
                 }
             }
         }
 
         // validate that there are no extraneous keys
         keys.each{ key ->
-            errors.add(new JTEException("Field '${key}' is not used."))
+            errors.add(new JTEException("${msgPrefix ? "${msgPrefix} " : ""}field '${key}' is not used."))
         }
 
         // if there are any errors, throw 'em

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/ApplicationEnvironmentSpec.groovy
@@ -430,4 +430,22 @@ class ApplicationEnvironmentSpec extends Specification {
         jenkins.buildAndAssertSuccess(job)
     }
 
+    @Issue("https://github.com/jenkinsci/templating-engine-plugin/issues/253")
+    def "Invalid ApplicationEnvironment configuration throws readable exception"(){
+        given:
+        WorkflowJob job = TestUtil.createAdHoc(jenkins,
+        config: """
+        application_environments{
+            property = "oops"
+        }
+        """,
+        template: 'null'
+        )
+        when:
+        WorkflowRun run = job.scheduleBuild2(0).get()
+        then:
+        jenkins.assertBuildStatus(Result.FAILURE, run)
+        jenkins.assertLogContains("Configuration for Application Environment property must be a Block but is a String", run)
+    }
+
 }

--- a/src/test/groovy/org/boozallen/plugins/jte/util/ConfigValidatorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/util/ConfigValidatorSpec.groovy
@@ -53,7 +53,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Field 'example' must be a String")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("field 'example' must be a String")
     }
 
     def "valid required key does not throw exception"() {
@@ -78,7 +79,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Missing required field 'example'")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("missing required field 'example'")
     }
 
     def "invalid optional key throws exception"() {
@@ -91,7 +93,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Field 'example' must be a String")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("field 'example' must be a String")
     }
 
     def "missing optional key is okay"() {
@@ -108,7 +111,7 @@ class ConfigValidatorSpec extends Specification {
 
     def "keys not in schema throw exception"() {
         setup:
-        String schema = 'fields{ required{ example = String } }'
+        String schema = 'fields{}'
         LinkedHashMap config = [ nope: 11 ]
 
         when:
@@ -116,7 +119,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Field 'nope' is not used.")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("field 'nope' is not used.")
     }
 
     def "nested required keys are validated"() {
@@ -129,7 +133,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Field 'nested.example' must be a String")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("field 'nested.example' must be a String")
     }
 
     def "nested optional keys are validated"() {
@@ -142,7 +147,8 @@ class ConfigValidatorSpec extends Specification {
 
         then:
         AggregateException ex = thrown()
-        ex.getMessage().contains("Field 'nested.example' must be a String")
+        assert ex.size() == 1
+        ex.getExceptions().first().getMessage().contains("field 'nested.example' must be a String")
     }
 
     def "aggregate exception has all errors"() {
@@ -169,9 +175,10 @@ class ConfigValidatorSpec extends Specification {
         then:
         AggregateException ex = thrown()
         ex.size() == 3
-        ex.getMessage().contains("Field 'fieldA' must be a String")
-        ex.getMessage().contains("Field 'fieldB' must be a Number")
-        ex.getMessage().contains("Field 'fieldC' must be a boolean")
+        List<String> messages = ex.getExceptions().collect{ e -> e.getMessage() }
+        assert messages.contains("field 'fieldA' must be a String but is a Integer")
+        assert messages.contains("field 'fieldB' must be a Number but is a String")
+        assert messages.contains("field 'fieldC' must be a boolean but is a Integer")
     }
 
     @Unroll


### PR DESCRIPTION
# PR Details

fixes #253 

also improves how `AggregateExceptions` are printed to the build log

## Description

Previously `AggregateException` would print the individual exception messages but there was no way to see the stack traces for those individual exceptions. 

<details><summary> previous screen shots </summary>

![image](https://user-images.githubusercontent.com/22510821/175426272-69cc1d7d-2b56-4bb1-a8c9-a894d67995b8.png)

</details>

When expanding the above image, you'd again just see the same message and single stack trace

<details><summary> expanded </summary>

![image](https://user-images.githubusercontent.com/22510821/175426318-ace8bda1-932e-48df-a739-54bb38542b9a.png)

</details>

This has been updated so that each exception message is individually printed and when expanded shows the stack track for that exception.

<details><summary> New Console Log Screenshot </summary>

![image](https://user-images.githubusercontent.com/22510821/175426399-03dfda36-bdfc-4d90-9c78-47d7b5e87aae.png)

</details>

## How Has This Been Tested

unit tests 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
