### PR TITLE
Do not save a `GString` as `Keyword.value`

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/KeywordInjector.groovy
@@ -35,7 +35,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
         // populate namespace with keywords from pipeline config
         LinkedHashMap aggregatedConfig = config.getConfig()
         aggregatedConfig[KEY].each{ key, value ->
-            Keyword keyword = new Keyword(name: key, value: value)
+            Keyword keyword = new Keyword(name: key, value: (value instanceof GString ? value.toString() : value))
             keyword.setParent(keywords)
             keywords.add(keyword)
         }


### PR DESCRIPTION
Might solve #311, just based on the stack trace. Or might not, or might cause other problems, or fix this one only to have the next JEP-200 violation break. Totally untested, YMMV.