### PR TITLE
Add support for BitBucket Pull Requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'org.jenkins-ci.plugins.workflow:workflow-api:2.28'
     implementation 'org.jenkins-ci.plugins:branch-api:2.0.20'
     implementation 'org.jenkins-ci.plugins:scm-api:2.2.7'
+    implementation 'org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source:2.4.1'
     implementation 'org.jenkins-ci.plugins:junit:1.24'
     implementation 'org.jenkins-ci.plugins:script-security:1.76'
     implementation 'org.jenkinsci.plugins:pipeline-model-definition:1.8.4' // version declarative started supporting JTE


### PR DESCRIPTION
# PR Details

Add support for Bitbucket Pull Requests

## Description

In order to properly retrieve Jenkins pipeline and template files in a repository, we must perform special detection and handling of BitBucket PRs.  Since the SCMHead retrieved from a PR Jenkins branch doesn't have the correct information to create an SCMFileSystem, we must detect if the SCMHead is of type com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead and then create a custom SCMHead of type com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead which points to the HEAD of the PRs source branch.  This allows us to create a SCMFileSystem that will allow us to retrieve the Jenkins pipeline_config.groovy and Jenkinsfile.

This PR fixes #308.

## How Has This Been Tested

JTE was inoperable against BitBucket Server 7.  After manually building the .hpi from this commit, we installed it and were able to confirm it working without issue.

Testing Environment:
* Jenkins 2.346.1
* BitBucket 7

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [ ] If necessary, I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
