### PR TITLE
upgrade jenkins baseline to recommended version 2.387.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: --no-daemon spotlessCheck
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: --no-daemon codenarc
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: --no-daemon test jacocoTestReport
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: --no-daemon jpi

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'groovy'
   id 'org.jenkins-ci.jpi' version '0.50.0-rc.3'
   id 'jacoco'
-  id "com.diffplug.spotless" version "6.13.0"
+  id "com.diffplug.spotless" version "6.20.0"
   id 'codenarc'
 }
 
@@ -18,7 +18,7 @@ version = '2.5.3'
 description = 'Allows users to create tool-agnostic, templated pipelines to be shared by multiple teams'
 
 jenkinsPlugin {
-    jenkinsVersion.set('2.346.3')
+    jenkinsVersion.set('2.387.3')
     pluginId.set('templating-engine')
     humanReadableName.set('Templating Engine')
     homePage.set(uri('https://github.com/jenkinsci/templating-engine-plugin'))
@@ -41,7 +41,7 @@ jenkinsPlugin {
 
 dependencies {
     // plugin dependencies
-    implementation platform('io.jenkins.tools.bom:bom-2.346.x:1763.v092b_8980a_f5e')
+    implementation platform('io.jenkins.tools.bom:bom-2.387.x:2278.v47b_4508e256a')
     implementation 'org.jenkins-ci.plugins.workflow:workflow-multibranch'
     implementation 'org.jenkins-ci.plugins.workflow:workflow-api'
     implementation 'org.jenkins-ci.plugins:branch-api'


### PR DESCRIPTION
# PR Details

following up #321 to the [latest recommendation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions) for the jenkins baseline to support. 

This will now require a version of Jenkins that requires Java 11. 

Also upgrading spotless to the latest version

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
