### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/concepts/library-development/library-source.md
+++ b/docs/concepts/library-development/library-source.md
@@ -25,4 +25,4 @@ The Plugin Library Source is used when libraries have been bundled into a separa
 This option will only be available in the Jenkins UI when a plugin has been installed that can serve as a library-providing plugin.
 
 !!! note "Learn More"
-    To learn more, check out [How to Package a Library Source as a Plugin](/how-to/library-development/package-libraries-as-plugin)
+    To learn more, check out [How to Package a Library Source as a Plugin](../../../how-to/library-development/package-libraries-as-plugin)


### PR DESCRIPTION
# PR Details

fixes #303 

The documentation links to the required content, but absolute links in mkdocs don't work because of the version number introduced into the URLs by `mike`. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
