### PR TITLE
update template show current plugin when select from plugin library source

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider.groovy
@@ -173,6 +173,10 @@ class PluginLibraryProvider extends LibraryProvider{
         return pluginDescriptor?.getDisplayName()
     }
 
+    LibraryProvidingPlugin getPlugin() {
+        return this.plugin
+    }
+
     @Extension
     static class DescriptorImpl extends LibraryProvider.LibraryProviderDescriptor{
 

--- a/src/main/resources/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider/config-detail.jelly
+++ b/src/main/resources/org/boozallen/plugins/jte/init/governance/libs/PluginLibraryProvider/config-detail.jelly
@@ -18,5 +18,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <f:dropdownDescriptorSelector title="Plugin" 
                                   field="plugin"
-                                  descriptors="${descriptor.getLibraryProvidingPlugins()}" /> 
+                                  descriptors="${descriptor.getLibraryProvidingPlugins()}"
+                                  default="${descriptor.getPlugin()}"
+                                   /> 
 </j:jelly>


### PR DESCRIPTION

# PR Details
This change supports the correct display of the plugin name used as the library source

<!--- Provide a general summary of your changes in the Title above -->

## Description
In cases where the library source is used as a plugin (the library is built into a plugin with better performance), users need to configure the library source on the system dashboard config or job config
However, the current plugin library provider template does not support displaying the exact name of the plugin being used on the system, which can lead to confusion.

<!--- Describe your changes in detail -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
