### PR TITLE
fix #343 by adding step related classes to whitelist

### DIFF
--- a/src/main/groovy/org/boozallen/plugins/jte/util/SandboxWhitelist.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/util/SandboxWhitelist.groovy
@@ -19,8 +19,11 @@ import hudson.Extension
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitive
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveCollector
 import org.boozallen.plugins.jte.init.primitives.TemplatePrimitiveNamespace
+import org.boozallen.plugins.jte.init.primitives.hooks.HookContext
 import org.boozallen.plugins.jte.init.primitives.hooks.HooksWrapper
 import org.boozallen.plugins.jte.init.primitives.injectors.LibraryNamespace
+import org.boozallen.plugins.jte.init.primitives.injectors.StageInjector
+import org.boozallen.plugins.jte.init.primitives.injectors.StepContext
 import org.boozallen.plugins.jte.init.primitives.injectors.StepWrapperScript
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AbstractWhitelist
 import org.boozallen.plugins.jte.init.governance.config.dsl.PipelineConfigurationBuilder
@@ -40,13 +43,17 @@ import java.lang.reflect.Method
     ]
 
     private final List<Class> permittedReceivers = [
-        TemplatePrimitive,
-        TemplatePrimitiveCollector.JTEVar,
-        TemplatePrimitiveNamespace,
-        LibraryNamespace,
-        HooksWrapper,
-        PipelineConfigurationBuilder,
-        DslEnvVar
+            TemplatePrimitive,
+            TemplatePrimitiveCollector.JTEVar,
+            TemplatePrimitiveNamespace,
+            LibraryNamespace,
+            HooksWrapper,
+            PipelineConfigurationBuilder,
+            DslEnvVar,
+            StepWrapperScript,
+            HookContext,
+            StepContext,
+            StageInjector.StageContext
     ]
 
     @Override

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjectorSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/injectors/LibraryStepInjectorSpec.groovy
@@ -225,4 +225,26 @@ class LibraryStepInjectorSpec extends Specification {
         jenkins.assertBuildStatusSuccess(run)
     }
 
+    def "folder libraries can access config variable"() {
+        given:
+        // add folder
+        TestLibraryProvider lib2 = new TestLibraryProvider()
+        lib2.addStep("lib", "step", """
+        void call(){
+          assert config.x == 1
+        }
+        """)
+        Folder folder = jenkins.createProject(Folder)
+        lib2.addToFolder(folder)
+        // create job
+        WorkflowJob job = TestUtil.createAdHocInFolder(folder,
+          config: 'libraries{ lib { x = 1 } }',
+          template: 'step()'
+        )
+        when:
+        def run = job.scheduleBuild2(0).get()
+        then:
+        jenkins.assertBuildStatusSuccess(run)
+    }
+
 }


### PR DESCRIPTION
# PR Details

fixes #343

## Description

adds step related classes to the pipeline whitelist now that library steps are sandboxed when loaded from a folder library source.

## How Has This Been Tested

added unit tests that reproduce regression

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Added Unit Testing
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added the appropriate label for this PR
- [x] If necessary, I have updated the documentation accordingly.
- [x] All new and existing tests passed.
